### PR TITLE
Fix out-of-bounds read in BLE proximity packet parser

### DIFF
--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -127,8 +127,11 @@ void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
     if (info.manufacturerData().contains(0x004C))
     {
         QByteArray data = info.manufacturerData().value(0x004C);
-        // Ensure data is long enough and starts with prefix 0x07 (indicates Proximity Pairing Message)
-        if (data.size() >= 10 && data[0] == 0x07)
+        // Ensure data is long enough and starts with prefix 0x07 (indicates Proximity Pairing Message).
+        // The fixed header runs through data[10] (11 bytes) and is followed by a 16-byte encrypted
+        // payload, so 27 is the real minimum; a size-only check against a lower bound (e.g. 10) let a
+        // forged advertisement from any nearby BLE device reach the data[10] read below out of bounds.
+        if (data.size() >= 27 && data[0] == 0x07)
         {
             QString address = info.address().toString();
             BleInfo deviceInfo;

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -5,6 +5,9 @@
 #include "logger.h"
 #include <QMap>
 
+// Fixed header data[0] through data[10], then a 16-byte encrypted payload.
+static constexpr int proximityPairingBytes = 11 + 16;
+
 AirpodsTrayApp::Enums::AirPodsModel getModelName(quint16 modelId)
 {
     using namespace AirpodsTrayApp::Enums;
@@ -127,11 +130,9 @@ void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
     if (info.manufacturerData().contains(0x004C))
     {
         QByteArray data = info.manufacturerData().value(0x004C);
-        // Ensure data is long enough and starts with prefix 0x07 (indicates Proximity Pairing Message).
-        // The fixed header runs through data[10] (11 bytes) and is followed by a 16-byte encrypted
-        // payload, so 27 is the real minimum; a size-only check against a lower bound (e.g. 10) let a
-        // forged advertisement from any nearby BLE device reach the data[10] read below out of bounds.
-        if (data.size() >= 27 && data[0] == 0x07)
+        // Sample input: 07 19 01 27 20 21 88 8F 11 00 04 <16 encrypted bytes>
+        // A shorter frame reads past data[10] and slices a wrong payload below, and any BLE device in range can send one.
+        if (data.size() >= proximityPairingBytes && data[0] == 0x07)
         {
             QString address = info.address().toString();
             BleInfo deviceInfo;

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -5,7 +5,7 @@
 # binary itself, since that would pull in BlueZ/PulseAudio/Qt6::Widgets.
 # Each test file is a single tst_*.cpp with QTEST_GUILESS_MAIN.
 
-find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(Qt6 REQUIRED COMPONENTS Test Core Bluetooth)
 
 # Centralized include path so tests can `#include "../eardetection.hpp"`
 # without each adding their own target_include_directories.
@@ -130,3 +130,11 @@ target_link_libraries(tst_qrcodeimageprovider
 target_include_directories(tst_qrcodeimageprovider PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set_target_properties(tst_qrcodeimageprovider PROPERTIES AUTOMOC ON)
 add_test(NAME tst_qrcodeimageprovider COMMAND tst_qrcodeimageprovider -platform offscreen)
+
+openpods_add_test(tst_blemanager
+    tst_blemanager.cpp
+    ../ble/blemanager.cpp
+    ../ble/blemanager.h
+)
+# Only test that parses a QBluetoothDeviceInfo, so only one needing the module.
+target_link_libraries(tst_blemanager PRIVATE Qt6::Bluetooth)

--- a/daemon/tests/tst_blemanager.cpp
+++ b/daemon/tests/tst_blemanager.cpp
@@ -1,0 +1,120 @@
+#include <QtTest>
+#include <QBluetoothAddress>
+#include <QBluetoothDeviceInfo>
+
+#include "../ble/blemanager.h"
+
+// main.cpp defines the Q_LOGGING_CATEGORY symbol, but tests don't link main.cpp.
+Q_LOGGING_CATEGORY(openpods, "openpods.test", QtWarningMsg)
+
+// Captured live: 07 19 01 27 20 21 88 8f 11 00 04 then the 16-byte encrypted payload.
+static const char *airPodsFrameHex = "071901272021888f110004b48a83d66c322a4745cb15da3fd6ab2b";
+// Captured in the same scan from another Apple device, 19 bytes and so under the fixed layout.
+static const char *otherAppleFrameHex = "071106e4dd8d647035112e2b36d341a6778984";
+
+static QBluetoothDeviceInfo advertisement(const QByteArray &data)
+{
+    QBluetoothDeviceInfo info(QBluetoothAddress("00:11:22:33:44:55"), QStringLiteral("AirPods"), 0);
+    info.setManufacturerData(0x004C, data);
+    return info;
+}
+
+// 0x10 is Apple's nearby info type, long enough to pass the size check and still not ours.
+static QByteArray typeSwapped(const QByteArray &frame)
+{
+    QByteArray other = frame;
+    other[0] = char(0x10);
+    return other;
+}
+
+// data[6] carries both pods, one nibble each, so an unequal byte separates them.
+static QByteArray withPodsBattery(const QByteArray &frame, quint8 podsByte)
+{
+    QByteArray other = frame;
+    other[6] = char(podsByte);
+    return other;
+}
+
+// Bit 5 of the status byte says the left pod is primary, and clearing it flips the nibbles.
+static QByteArray withRightPodPrimary(const QByteArray &frame)
+{
+    QByteArray other = frame;
+    other[5] = char(quint8(other[5]) & ~0x20);
+    return other;
+}
+
+// Emissions for one frame, or -1 when the slot could not be invoked at all.
+static int parseFrame(const QByteArray &frame, BleInfo *emitted)
+{
+    BleManager manager;
+    int emissions = 0;
+    QObject::connect(&manager, &BleManager::deviceFound, &manager, [&](const BleInfo &device) {
+        if (emitted)
+            *emitted = device;
+        ++emissions;
+    });
+
+    if (!QMetaObject::invokeMethod(&manager, "onDeviceDiscovered", Qt::DirectConnection,
+                                   Q_ARG(QBluetoothDeviceInfo, advertisement(frame))))
+        return -1;
+
+    return emissions;
+}
+
+class TestBleManager : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void unparseableFrameIsDropped_data();
+    void unparseableFrameIsDropped();
+    void realAirPodsFrameIsParsed();
+    void podsBatteryKeepsLeftAndRightApart();
+};
+
+void TestBleManager::unparseableFrameIsDropped_data()
+{
+    const QByteArray airPods = QByteArray::fromHex(airPodsFrameHex);
+
+    QTest::addColumn<QByteArray>("frame");
+    QTest::newRow("empty payload") << QByteArray();
+    QTest::newRow("10 bytes, one past the end at the data[10] read") << airPods.left(10);
+    QTest::newRow("19 bytes, a real Apple advertisement under the fixed layout") << QByteArray::fromHex(otherAppleFrameHex);
+    QTest::newRow("26 bytes, one short of the fixed layout") << airPods.left(26);
+    QTest::newRow("full length but not a proximity pairing type") << typeSwapped(airPods);
+}
+
+void TestBleManager::unparseableFrameIsDropped()
+{
+    QFETCH(QByteArray, frame);
+
+    QCOMPARE(parseFrame(frame, nullptr), 0);
+}
+
+void TestBleManager::realAirPodsFrameIsParsed()
+{
+    BleInfo parsed;
+
+    QCOMPARE(parseFrame(QByteArray::fromHex(airPodsFrameHex), &parsed), 1);
+    // Decoded from the capture: 0x8f is a case nibble of 15 meaning absent, 0x04 is idle.
+    QCOMPARE(parsed.caseBattery, -1);
+    QCOMPARE(parsed.connectionState, BleInfo::ConnectionState::IDLE);
+}
+
+void TestBleManager::podsBatteryKeepsLeftAndRightApart()
+{
+    const QByteArray unequalPods = withPodsBattery(QByteArray::fromHex(airPodsFrameHex), 0x82);
+    BleInfo parsed;
+
+    // The capture's status byte 0x21 has bit 5 set, so the low nibble belongs to the left pod.
+    QCOMPARE(parseFrame(unequalPods, &parsed), 1);
+    QCOMPARE(parsed.leftPodBattery, 20);
+    QCOMPARE(parsed.rightPodBattery, 80);
+
+    QCOMPARE(parseFrame(withRightPodPrimary(unequalPods), &parsed), 1);
+    QCOMPARE(parsed.leftPodBattery, 80);
+    QCOMPARE(parsed.rightPodBattery, 20);
+}
+
+QTEST_GUILESS_MAIN(TestBleManager)
+#include "tst_blemanager.moc"


### PR DESCRIPTION
## Summary
- `BleManager::onDeviceDiscovered` in `daemon/ble/blemanager.cpp` only required `data.size() >= 10` before reading fields up through `data[10]`, and before slicing the trailing 16-byte encrypted payload with `data.size() - 16`.
- A forged Apple-manufacturer-ID (`0x004C`) BLE advertisement between 10 and 26 bytes, starting with the `0x07` proximity-message prefix, would pass that guard and trigger a 1-byte out-of-bounds read via the unchecked `QByteArray::operator[]` at `data[10]`, plus feed an undersized/negative length into `left()`/`mid()`.
- A genuine AirPods proximity message is 11 header bytes followed by a 16-byte encrypted payload, so 27 is the real minimum length. This raises the guard to match, so undersized/forged packets are rejected before any of the fixed-offset reads run.

## Why this matters
This parser runs on any nearby BLE advertisement carrying Apple's manufacturer ID, not just your own paired AirPods — so it's reachable by any device in range, not just your own hardware. Worst-case impact is bounded (a read, not a write, feeding into an enum field), but it's still a length-validation gap worth closing before treating this parser as hardened.

## Testing
- Built with `cmake -B build -G Ninja && cmake --build build` — no warnings from the changed file.
- Full existing test suite passes: `ctest` — 15/15 tests pass (no test currently exercises `BleManager::onDeviceDiscovered` directly).
- Installed the built daemon (`cmake --install build --prefix ~/.local`) and ran it live against a paired AirPods Pro 3 via `librepods.service` — confirmed correct battery, model (`A3063`/`AirPods Pro 3`), ear-detection, and noise-mode reporting through `librepods-ctl status` and the bar panel, with no regressions from the stricter length check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth advertisement validation to safely reject incomplete manufacturer data.
  * Prevented malformed proximity pairing messages from being processed.
  * Improved reliability when detecting and reporting Bluetooth device connection states and battery levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->