### PR TITLE
Publish the AirPods Max battery

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -47,6 +47,7 @@ function defaultStatus() {
     deviceName: "",
     modelName: "",
     isProSeries: false,
+    isHeadset: false,
     supportsNoiseOff: true,
     noiseMode: NOISE_UNKNOWN,
     adaptiveNoiseLevel: 0,
@@ -56,7 +57,8 @@ function defaultStatus() {
     lidState: LID_UNKNOWN,
     left: defaultPod(),
     right: defaultPod(),
-    caseBattery: { level: LEVEL_UNKNOWN, charging: false }
+    caseBattery: { level: LEVEL_UNKNOWN, charging: false },
+    headset: { level: LEVEL_UNKNOWN, charging: false }
   }
 }
 
@@ -90,6 +92,10 @@ function podFrom(raw) {
 //  "reopen_calls_total":0,
 //  "right":{"available":true,"charging":true,"in_ear":false,"level":100},
 //  "schema_version":1,"supports_noise_off":false}
+//
+// A headset (AirPods Max) instead carries "is_headset":true and
+// "headset":{"available":true,"charging":false,"level":100}, with left, right
+// and case all absent or unavailable — one battery, no pods, no case.
 function parseStatus(raw) {
   var status = defaultStatus()
   var text = String(raw || "").trim()
@@ -123,6 +129,10 @@ function parseStatus(raw) {
   status.deviceName = String(parsed.device_name || "")
   status.modelName = String(parsed.model_name || "")
   status.isProSeries = parsed.is_pro_series === true
+  // AirPods Max: one battery in "headset", no pods and no case. Daemons older
+  // than the headset fix send neither key, so this stays false and the panel
+  // keeps drawing the pod rows.
+  status.isHeadset = parsed.is_headset === true
   // Older daemons do not send this, and every model before the Pro 3 had Off.
   status.supportsNoiseOff = parsed.supports_noise_off !== false
   status.noiseMode = intOr(parsed.noise_mode, NOISE_UNKNOWN)
@@ -135,6 +145,8 @@ function parseStatus(raw) {
   status.right = podFrom(parsed.right)
   var caseRaw = podFrom(parsed["case"])
   status.caseBattery = { level: caseRaw.level, charging: caseRaw.charging }
+  var headsetRaw = podFrom(parsed.headset)
+  status.headset = { level: headsetRaw.level, charging: headsetRaw.charging }
   return status
 }
 

--- a/Model.js
+++ b/Model.js
@@ -92,10 +92,7 @@ function podFrom(raw) {
 //  "reopen_calls_total":0,
 //  "right":{"available":true,"charging":true,"in_ear":false,"level":100},
 //  "schema_version":1,"supports_noise_off":false}
-//
-// A headset (AirPods Max) instead carries "is_headset":true and
-// "headset":{"available":true,"charging":false,"level":100}, with left, right
-// and case all absent or unavailable — one battery, no pods, no case.
+// A headset (AirPods Max) instead sends "is_headset":true and "headset":{"available":true,"charging":false,"level":100}, with no pods and no case.
 function parseStatus(raw) {
   var status = defaultStatus()
   var text = String(raw || "").trim()
@@ -129,9 +126,7 @@ function parseStatus(raw) {
   status.deviceName = String(parsed.device_name || "")
   status.modelName = String(parsed.model_name || "")
   status.isProSeries = parsed.is_pro_series === true
-  // AirPods Max: one battery in "headset", no pods and no case. Daemons older
-  // than the headset fix send neither key, so this stays false and the panel
-  // keeps drawing the pod rows.
+  // Older daemons send neither key, so this stays false and the pod rows keep drawing.
   status.isHeadset = parsed.is_headset === true
   // Older daemons do not send this, and every model before the Pro 3 had Off.
   status.supportsNoiseOff = parsed.supports_noise_off !== false

--- a/Panel.qml
+++ b/Panel.qml
@@ -242,9 +242,20 @@ Panel {
               width: parent.width
               spacing: Style.space(6)
 
-              PodRow { width: parent.width; label: "Left"; pod: pods.leftPod }
-              PodRow { width: parent.width; label: "Right"; pod: pods.rightPod }
+              // A Max has one battery and no case, so the pod trio would draw two
+              // dashes and a phantom flat case. Column skips invisible children,
+              // so only the shape the hardware actually has takes up space.
               PodRow {
+                visible: pods.isHeadset
+                width: parent.width
+                label: "Headphones"
+                wideLabel: true
+                pod: ({ level: pods.headsetBattery.level, charging: pods.headsetBattery.charging, inEar: false })
+              }
+              PodRow { visible: !pods.isHeadset; width: parent.width; label: "Left"; pod: pods.leftPod }
+              PodRow { visible: !pods.isHeadset; width: parent.width; label: "Right"; pod: pods.rightPod }
+              PodRow {
+                visible: !pods.isHeadset
                 width: parent.width
                 label: "Case"
                 pod: ({ level: pods.caseBattery.level, charging: pods.caseBattery.charging, inEar: false })
@@ -382,6 +393,8 @@ Panel {
     property string label: ""
     property var pod: Model.defaultPod()
     property string meta: ""
+    // Only set by a row whose label does not fit the column cut for Left/Right/Case.
+    property bool wideLabel: false
 
     readonly property string metaText: meta !== "" ? meta : Model.podMeta(pod)
     readonly property bool low: pod.level !== Model.LEVEL_UNKNOWN
@@ -402,7 +415,12 @@ Panel {
         opacity: 0.6
         font.family: root.fontFamily
         font.pixelSize: Style.font.bodySmall
-        Layout.preferredWidth: Style.space(44)
+        // The fixed 44 was cut for Left, Right and Case. A longer label such as
+        // Headphones overflows under the meter, so that row opts in to a column
+        // wide enough for its text; every earbud row keeps the original binding
+        // untouched rather than being resized in sympathy.
+        Layout.preferredWidth: podRow.wideLabel ? Math.max(Style.space(44), implicitWidth + Style.space(10))
+                                                : Style.space(44)
       }
 
       Rectangle {

--- a/Panel.qml
+++ b/Panel.qml
@@ -242,14 +242,11 @@ Panel {
               width: parent.width
               spacing: Style.space(6)
 
-              // A Max has one battery and no case, so the pod trio would draw two
-              // dashes and a phantom flat case. Column skips invisible children,
-              // so only the shape the hardware actually has takes up space.
+              // A Max has one battery and no case, so the pod trio would draw two dashes and a phantom case.
               PodRow {
                 visible: pods.isHeadset
                 width: parent.width
                 label: "Headphones"
-                wideLabel: true
                 pod: ({ level: pods.headsetBattery.level, charging: pods.headsetBattery.charging, inEar: false })
               }
               PodRow { visible: !pods.isHeadset; width: parent.width; label: "Left"; pod: pods.leftPod }
@@ -393,8 +390,6 @@ Panel {
     property string label: ""
     property var pod: Model.defaultPod()
     property string meta: ""
-    // Only set by a row whose label does not fit the column cut for Left/Right/Case.
-    property bool wideLabel: false
 
     readonly property string metaText: meta !== "" ? meta : Model.podMeta(pod)
     readonly property bool low: pod.level !== Model.LEVEL_UNKNOWN
@@ -415,12 +410,8 @@ Panel {
         opacity: 0.6
         font.family: root.fontFamily
         font.pixelSize: Style.font.bodySmall
-        // The fixed 44 was cut for Left, Right and Case. A longer label such as
-        // Headphones overflows under the meter, so that row opts in to a column
-        // wide enough for its text; every earbud row keeps the original binding
-        // untouched rather than being resized in sympathy.
-        Layout.preferredWidth: podRow.wideLabel ? Math.max(Style.space(44), implicitWidth + Style.space(10))
-                                                : Style.space(44)
+        // Style.space(44) was cut for Left, Right and Case, so a longer label takes the room it needs.
+        Layout.preferredWidth: Math.max(Style.space(44), implicitWidth + Style.space(10))
       }
 
       Rectangle {

--- a/Service.qml
+++ b/Service.qml
@@ -13,6 +13,7 @@ Item {
   property string deviceName: ""
   property string modelName: ""
   property bool isProSeries: false
+  property bool isHeadset: false
   property bool supportsNoiseOff: true
   property int noiseMode: Model.NOISE_UNKNOWN
   property int adaptiveNoiseLevel: 0
@@ -24,6 +25,7 @@ Item {
   property var leftPod: Model.defaultPod()
   property var rightPod: Model.defaultPod()
   property var caseBattery: ({ level: Model.LEVEL_UNKNOWN, charging: false })
+  property var headsetBattery: ({ level: Model.LEVEL_UNKNOWN, charging: false })
   property string lastError: ""
   property string actionStatus: ""
 
@@ -35,9 +37,11 @@ Item {
   readonly property bool hasAirPods: daemonReachable && connected
   // Battery keeps arriving over BLE while the audio link is down, so it is not gated on connected.
   readonly property bool hasBattery: daemonReachable
-    && (leftPod.level !== Model.LEVEL_UNKNOWN
-      || rightPod.level !== Model.LEVEL_UNKNOWN
-      || caseBattery.level !== Model.LEVEL_UNKNOWN)
+    && (isHeadset
+      ? headsetBattery.level !== Model.LEVEL_UNKNOWN
+      : (leftPod.level !== Model.LEVEL_UNKNOWN
+        || rightPod.level !== Model.LEVEL_UNKNOWN
+        || caseBattery.level !== Model.LEVEL_UNKNOWN))
 
   // How long an optimistic value is held before the daemon's own state wins.
   readonly property int settleHoldMs: 4000
@@ -90,10 +94,12 @@ Item {
     deviceName = status.deviceName
     modelName = status.modelName
     isProSeries = status.isProSeries
+    isHeadset = status.isHeadset
     supportsNoiseOff = status.supportsNoiseOff
     leftPod = status.left
     rightPod = status.right
     caseBattery = status.caseBattery
+    headsetBattery = status.headset
     lidState = status.lidState
 
     noiseMode = _settle("noiseMode", status.noiseMode)

--- a/daemon/battery.hpp
+++ b/daemon/battery.hpp
@@ -157,6 +157,7 @@ public:
         return true;
     }
 
+    // Sample input: 16 decrypted bytes, [1] and [2] the pods (a headset uses [1] alone), [3] the case, high bit charging.
     bool parseEncryptedPacket(const QByteArray &packet, bool isLeftPodPrimary, bool podInCase, bool isHeadset)
     {
         // Validate packet size (expect 16 bytes based on provided payloads)
@@ -179,20 +180,12 @@ public:
         auto [isRightCharging, rawRightBattery] = formatBattery(rawRightBatteryByte);
         auto [isCaseCharging, rawCaseBattery] = formatBattery(rawCaseBatteryByte);
         if (isHeadset) {
-            // A headset carries its single battery in payload byte 1, and the
-            // isLeftPodPrimary flip does not move it. That flip is an earbuds
-            // concept: with two pods it decides which byte is the left one, but
-            // on a Max it only renames the same byte, so following the mapping
-            // made the level appear to hop between the left and right slots
-            // whenever primary changed -- and the slot it hopped out of reads 0,
-            // not the 0x7F that means unknown, so the old scan adopted that zero
-            // and the panel flickered 100% -> 0% -> 100% every time the
-            // headphones came off. Reading the byte directly keeps a genuine 0%
-            // distinguishable from the slot a headset simply does not use.
+            // A headset keeps its one battery in byte 1, and the primary flip only renames that byte.
             auto [headsetCharging, headsetLevel] =
                 formatBattery(static_cast<unsigned char>(packet.at(1)));
             primaryPod = Component::Headset;
-            if (headsetLevel != CHAR_MAX && headsetLevel <= 100) {
+            // formatBattery masks to 0-127, so this also drops the 0x7F that means unknown.
+            if (headsetLevel <= 100) {
                 states[Component::Headset] = {static_cast<quint8>(headsetLevel),
                     headsetCharging ? BatteryStatus::Charging : BatteryStatus::Discharging};
             }

--- a/daemon/battery.hpp
+++ b/daemon/battery.hpp
@@ -179,15 +179,22 @@ public:
         auto [isRightCharging, rawRightBattery] = formatBattery(rawRightBatteryByte);
         auto [isCaseCharging, rawCaseBattery] = formatBattery(rawCaseBatteryByte);
         if (isHeadset) {
-            int batteries[] = {rawLeftBattery, rawRightBattery, rawCaseBattery};
-            bool statuses[] = {isLeftCharging, isRightCharging, isCaseCharging};
-            // Find the first battery that isn't CHAR_MAX
-            auto it = std::find_if(std::begin(batteries), std::end(batteries), [](int i) { return i != CHAR_MAX; });
-            if (it != std::end(batteries)) {
-                std::size_t idx = it - std::begin(batteries);
-                int battery = *it;
-                primaryPod = Component::Headset;
-                states[Component::Headset] =  {static_cast<quint8>(battery), statuses[idx] ? BatteryStatus::Charging : BatteryStatus::Discharging};
+            // A headset carries its single battery in payload byte 1, and the
+            // isLeftPodPrimary flip does not move it. That flip is an earbuds
+            // concept: with two pods it decides which byte is the left one, but
+            // on a Max it only renames the same byte, so following the mapping
+            // made the level appear to hop between the left and right slots
+            // whenever primary changed -- and the slot it hopped out of reads 0,
+            // not the 0x7F that means unknown, so the old scan adopted that zero
+            // and the panel flickered 100% -> 0% -> 100% every time the
+            // headphones came off. Reading the byte directly keeps a genuine 0%
+            // distinguishable from the slot a headset simply does not use.
+            auto [headsetCharging, headsetLevel] =
+                formatBattery(static_cast<unsigned char>(packet.at(1)));
+            primaryPod = Component::Headset;
+            if (headsetLevel != CHAR_MAX && headsetLevel <= 100) {
+                states[Component::Headset] = {static_cast<quint8>(headsetLevel),
+                    headsetCharging ? BatteryStatus::Charging : BatteryStatus::Discharging};
             }
         } else {
             if (rawLeftBattery == CHAR_MAX) {

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1207,9 +1207,7 @@ private slots:
             // is -1 when the broadcast nibble was 15 (unknown); the
             // setter skips those so we don't clobber a valid prior
             // reading.
-            // A Max has no case, and its adv's case nibble decodes to 0 rather
-            // than to the 15 that means unknown, so feeding it in marks
-            // Component::Case available at 0% and invents a flat case row.
+            // A Max has no case, and its nibble decodes to 0 rather than the 15 that means unknown.
             if (!isModelHeadset(m_deviceInfo->model())) {
                 m_deviceInfo->getBattery()->setCaseFromBle(device.caseBattery, device.caseCharging);
             }
@@ -1424,10 +1422,7 @@ public:
             caseObj.insert("level",    b->getCaseLevel());
             caseObj.insert("charging", b->isCaseCharging());
             status.insert("case", caseObj);
-            // An AirPods Max reports a single battery in Component::Headset,
-            // which the left/right/case trio cannot express: both pods read
-            // unavailable and there is no case at all. Publish it under its own
-            // key so the panel has a real level to draw instead of two dashes.
+            // A Max reports one battery in Component::Headset, which left, right and case cannot express.
             QJsonObject headsetObj;
             headsetObj.insert("available", b->isHeadsetAvailable());
             headsetObj.insert("level",    b->getHeadsetLevel());
@@ -1453,8 +1448,7 @@ public:
         status.insert("model_name", d ? modelDisplayName(d->model()) : QString());
         status.insert("model_int", d ? static_cast<int>(d->model()) : 0);
         status.insert("is_pro_series", d ? isProSeriesAirPods(d->model()) : false);
-        // Headset models carry one battery and no case, so a panel needs to know
-        // which shape to draw before any battery packet has arrived.
+        // The panel needs the shape before any battery packet has arrived.
         status.insert("is_headset", d ? isModelHeadset(d->model()) : false);
         status.insert("supports_noise_off", d ? supportsNoiseOff(d->model()) : true);
         // Raw "A<NNNN>" code from the AAP metadata packet. Useful

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1207,7 +1207,12 @@ private slots:
             // is -1 when the broadcast nibble was 15 (unknown); the
             // setter skips those so we don't clobber a valid prior
             // reading.
-            m_deviceInfo->getBattery()->setCaseFromBle(device.caseBattery, device.caseCharging);
+            // A Max has no case, and its adv's case nibble decodes to 0 rather
+            // than to the 15 that means unknown, so feeding it in marks
+            // Component::Case available at 0% and invents a flat case row.
+            if (!isModelHeadset(m_deviceInfo->model())) {
+                m_deviceInfo->getBattery()->setCaseFromBle(device.caseBattery, device.caseCharging);
+            }
             m_deviceInfo->getEarDetection()->overrideEarDetectionStatus(device.isPrimaryInEar, device.isSecondaryInEar);
             m_lidState = device.lidState;
         }
@@ -1419,6 +1424,15 @@ public:
             caseObj.insert("level",    b->getCaseLevel());
             caseObj.insert("charging", b->isCaseCharging());
             status.insert("case", caseObj);
+            // An AirPods Max reports a single battery in Component::Headset,
+            // which the left/right/case trio cannot express: both pods read
+            // unavailable and there is no case at all. Publish it under its own
+            // key so the panel has a real level to draw instead of two dashes.
+            QJsonObject headsetObj;
+            headsetObj.insert("available", b->isHeadsetAvailable());
+            headsetObj.insert("level",    b->getHeadsetLevel());
+            headsetObj.insert("charging", b->isHeadsetCharging());
+            status.insert("headset", headsetObj);
         }
         status.insert("reconnect_attempts_total", reconnectAttemptsTotal());
         status.insert("reconnect_failures_total", reconnectFailuresTotal());
@@ -1439,6 +1453,9 @@ public:
         status.insert("model_name", d ? modelDisplayName(d->model()) : QString());
         status.insert("model_int", d ? static_cast<int>(d->model()) : 0);
         status.insert("is_pro_series", d ? isProSeriesAirPods(d->model()) : false);
+        // Headset models carry one battery and no case, so a panel needs to know
+        // which shape to draw before any battery packet has arrived.
+        status.insert("is_headset", d ? isModelHeadset(d->model()) : false);
         status.insert("supports_noise_off", d ? supportsNoiseOff(d->model()) : true);
         // Raw "A<NNNN>" code from the AAP metadata packet. Useful
         // for debugging new/unrecognized models — if a fresh

--- a/daemon/tests/tst_battery.cpp
+++ b/daemon/tests/tst_battery.cpp
@@ -159,13 +159,7 @@ private slots:
         QCOMPARE(b.getCaseLevel(), quint8(80));
     }
 
-    // A headset keeps its single battery in payload byte 1, but isLeftPodPrimary
-    // flips when the headphones come off, which renames that byte from the left
-    // slot to the right one. Following the mapping made the level look like it had
-    // moved to a slot reading 0 -- not the 0x7F that means unknown -- so the panel
-    // flickered 100% -> 0% -> 100% on every off/on. Observed on AirPods Max
-    // (USB-C, A3184): rawByte1 held 100 across both states while primaryLeft went
-    // true -> false.
+    // Observed on an AirPods Max (USB-C, A3184): byte 1 held 100 while primaryLeft went true then false.
     void encryptedHeadset_levelSurvivesThePrimaryFlip()
     {
         Battery b;
@@ -178,8 +172,7 @@ private slots:
         QCOMPARE(b.getHeadsetLevel(), quint8(100));
     }
 
-    // The unused slot reads 0, so 0 must not be filtered as "unknown" -- an empty
-    // headset has to be able to report itself empty.
+    // The unused slot reads 0, so a real 0 must stay distinguishable from unknown.
     void encryptedHeadsetZero_isARealReading()
     {
         Battery b;
@@ -188,15 +181,21 @@ private slots:
         QCOMPARE(b.getHeadsetLevel(), quint8(0));
     }
 
+    void encryptedHeadsetUnknown_leavesTheHeadsetUnavailable()
+    {
+        Battery b;
+        QVERIFY(b.parseEncryptedPacket(payload(0x7F, 0, 0), true, false, true));
+        QVERIFY(!b.isHeadsetAvailable());
+    }
+
     void encryptedHeadsetUnknown_leavesTheKnownLevelAlone()
     {
         Battery b;
         QVERIFY(b.parsePacket(headsetPacket(100)));
         QCOMPARE(b.getHeadsetLevel(), quint8(100));
 
-        // 0x7F is the documented unknown marker; a level already established over
-        // the AAP battery packet outlives it.
-        QVERIFY(b.parseEncryptedPacket(payload(0x7F, 100, 0), true, false, true));
+        // 0x7F means unknown, and slot 2's 50 is what the old first-non-unknown scan would have adopted.
+        QVERIFY(b.parseEncryptedPacket(payload(0x7F, 50, 0), true, false, true));
         QCOMPARE(b.getHeadsetLevel(), quint8(100));
     }
 

--- a/daemon/tests/tst_battery.cpp
+++ b/daemon/tests/tst_battery.cpp
@@ -158,6 +158,73 @@ private slots:
         QVERIFY(b.isCaseAvailable());
         QCOMPARE(b.getCaseLevel(), quint8(80));
     }
+
+    // A headset keeps its single battery in payload byte 1, but isLeftPodPrimary
+    // flips when the headphones come off, which renames that byte from the left
+    // slot to the right one. Following the mapping made the level look like it had
+    // moved to a slot reading 0 -- not the 0x7F that means unknown -- so the panel
+    // flickered 100% -> 0% -> 100% on every off/on. Observed on AirPods Max
+    // (USB-C, A3184): rawByte1 held 100 across both states while primaryLeft went
+    // true -> false.
+    void encryptedHeadset_levelSurvivesThePrimaryFlip()
+    {
+        Battery b;
+        QVERIFY(b.parseEncryptedPacket(payload(100, 0, 0), true, false, true));
+        QCOMPARE(b.getHeadsetLevel(), quint8(100));
+
+        // Same bytes, primary flipped: the reading must not move.
+        QVERIFY(b.parseEncryptedPacket(payload(100, 0, 0), false, false, true));
+        QVERIFY(b.isHeadsetAvailable());
+        QCOMPARE(b.getHeadsetLevel(), quint8(100));
+    }
+
+    // The unused slot reads 0, so 0 must not be filtered as "unknown" -- an empty
+    // headset has to be able to report itself empty.
+    void encryptedHeadsetZero_isARealReading()
+    {
+        Battery b;
+        QVERIFY(b.parseEncryptedPacket(payload(0, 0, 0), true, false, true));
+        QVERIFY(b.isHeadsetAvailable());
+        QCOMPARE(b.getHeadsetLevel(), quint8(0));
+    }
+
+    void encryptedHeadsetUnknown_leavesTheKnownLevelAlone()
+    {
+        Battery b;
+        QVERIFY(b.parsePacket(headsetPacket(100)));
+        QCOMPARE(b.getHeadsetLevel(), quint8(100));
+
+        // 0x7F is the documented unknown marker; a level already established over
+        // the AAP battery packet outlives it.
+        QVERIFY(b.parseEncryptedPacket(payload(0x7F, 100, 0), true, false, true));
+        QCOMPARE(b.getHeadsetLevel(), quint8(100));
+    }
+
+    void encryptedHeadsetCharging_comesFromTheHighBit()
+    {
+        Battery b;
+        QVERIFY(b.parseEncryptedPacket(payload(90, 0, 0), true, false, true));
+        QCOMPARE(b.getHeadsetLevel(), quint8(90));
+        QVERIFY(!b.isHeadsetCharging());
+
+        QVERIFY(b.parseEncryptedPacket(payload(0x80 | 90, 0, 0), true, false, true));
+        QCOMPARE(b.getHeadsetLevel(), quint8(90));
+        QVERIFY(b.isHeadsetCharging());
+    }
+
+private:
+    // The AAP battery packet for a headset, which is what establishes a real level.
+    QByteArray headsetPacket(int level)
+    {
+        QByteArray buf = AirPodsPackets::Parse::BATTERY_STATUS;
+        buf.append(static_cast<char>(1));
+        buf.append(static_cast<char>(Battery::Component::Headset));
+        buf.append(static_cast<char>(0x01));
+        buf.append(static_cast<char>(level));
+        buf.append(static_cast<char>(Battery::BatteryStatus::Discharging));
+        buf.append(static_cast<char>(0x01));
+        return buf;
+    }
 };
 
 QTEST_GUILESS_MAIN(TestBattery)

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -81,6 +81,23 @@ check("an elided error is one line", long.indexOf("\n"), -1)
 check("an elided error fits the row", long.length <= Model.MAX_ERROR_CHARS, true)
 check("elideError copes with nothing", Model.elideError(null), "")
 
+// A Max sends one battery under "headset" and no pods at all, so the panel needs the flag to pick a shape.
+const max = Model.parseStatus('{"connected":true,"device_name":"AirPods Max","headset":{"available":true,"charging":false,"level":100},"is_headset":true,"model_name":"AirPods Max","noise_mode":1,"schema_version":1}')
+check("max line parses", max.ok, true)
+check("max is flagged a headset", max.isHeadset, true)
+check("max headset level", max.headset, { level: 100, charging: false })
+check("max has no pods", max.left.level, Model.LEVEL_UNKNOWN)
+check("max has no case", max.caseBattery.level, Model.LEVEL_UNKNOWN)
+
+// Between connect and the first battery packet the daemon sends the flag with no headset object at all.
+const maxFresh = Model.parseStatus('{"connected":true,"is_headset":true,"noise_mode":1,"schema_version":1}')
+check("max before any battery packet is still a headset", maxFresh.isHeadset, true)
+check("max before any battery packet has no level", maxFresh.headset.level, Model.LEVEL_UNKNOWN)
+
+// A daemon too old to send is_headset must keep drawing the pod rows rather than an empty headset row.
+check("no is_headset key means earbuds", good.isHeadset, false)
+check("no headset key is unknown, not zero", good.headset.level, Model.LEVEL_UNKNOWN)
+
 if (failures > 0) {
   console.log(failures + " failed")
   Deno.exit(1)


### PR DESCRIPTION
On an AirPods Max the panel showed `--` for both pods and a `0%` case the hardware does not have. The daemon reads the battery correctly — the log says `Battery status: "Headset: 100%"` — but it never reached the panel.

![AirPods Max panel](https://raw.githubusercontent.com/nicdal/omarchy-pods/pr-assets/airpods-max-panel.png)

### Three causes

1. `statusJson()` only serialized `left`, `right` and `case`, so `Component::Headset` was dropped at the JSON boundary.
2. `setCaseFromBle` ran for headsets. A Max's adv case nibble decodes to `0` rather than to the `15` that means unknown, so `Component::Case` was marked available at 0% — inventing a case. This also makes the existing comment in `enums.h` true: *"the battery.hpp side never marks caseAvailable=true for headsets"*.
3. `parseEncryptedPacket` followed the `isLeftPodPrimary` mapping for headsets. That flip renames the same payload byte from the left slot to the right one, so the level appeared to move into a slot reading `0` and the old scan adopted it. The panel flickered 100% → 0% → 100% on every off/on.

Measured on the hardware, one payload byte, two primary states:

| state | `primaryLeft` | `rawByte1` | mappedLeft | mappedRight |
|---|---|---|---|---|
| on head | `true` | 100 | 100 | 0 |
| off head | `false` | 100 | 0 | 100 |

The byte never moves, so a headset now reads it directly. No zero-filtering, which keeps a genuinely empty headset able to report 0%.

### Changes

- `statusJson()` publishes `headset` and `is_headset`. Additive — no schema bump, and older panels keep reading the trio unchanged.
- `setCaseFromBle` is skipped for headsets, matching the flag already passed to `parseEncryptedPacket`.
- A headset's level comes from payload byte 1.
- Panel draws one `Headphones` row for a headset. Earbud rows keep their bindings untouched, label column width included.
- Four headset tests. `encryptedHeadset_levelSurvivesThePrimaryFlip` fails without the byte-1 fix; `encryptedHeadsetZero_isARealReading` fails against a zero-filtering implementation.

### Testing

- AirPods Max (USB-C, A3184): `status.json` reports `headset {available:true, level:100}` with `case available:false`, and the level holds through off/on cycles.
- AirPods Max (Lightning, A2096) takes the same path via `isModelHeadset` but I have no unit to test on.
- AirPods Pro: verified by feeding the panel simulated status files rather than on hardware — both an old-daemon shape (no `is_headset`) and a new-daemon shape (`is_headset:false`) render Left/Right/Case exactly as before. All pre-existing earbud tests pass; the earbud branch in `battery.hpp` is unchanged. 15/15 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added battery monitoring for headset devices, including AirPods Max.
  * Displays a single “Headphones” row with charge level and charging status.
  * Preserves separate left, right, and case battery levels for AirPods.

* **Bug Fixes**
  * Correctly handles 0% battery readings.
  * Prevents unknown or invalid readings from overwriting valid battery information.
  * Maintains compatibility with devices that do not provide headset status data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->