### PR TITLE
Fix AirPods audio stutters

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -647,6 +647,19 @@ public slots:
     int loadRetryAttempts() const { return m_settings->value("bluetooth/retryAttempts", 3).toInt(); }
     void saveRetryAttempts(int attempts) { m_settings->setValue("bluetooth/retryAttempts", attempts); }
 
+    void stopBleScanWhileConnected()
+    {
+        if (!areAirpodsConnected() || !m_bleManager->isScanning())
+            return;
+
+        // This controller carries A2DP and BLE on the same radio. Continuous
+        // discovery while audio is active coincides with malformed advertising
+        // reports and missing A2DP completion reports on this Broadcom
+        // controller, so favor uninterrupted audio once the AAP link is live.
+        LOG_INFO("Stopping BLE scan while AirPods control link is connected");
+        m_bleManager->stopScan();
+    }
+
     void onSystemGoingToSleep()
     {
         m_isSuspending = true;
@@ -668,10 +681,9 @@ public slots:
         // the disconnect notifications that BlueZ fires during resume
         // don't surface as user-visible "AirPods Disconnected" toasts.
         QTimer::singleShot(2000, this, [this]() {
-            m_bleManager->startScan();
-
             if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
             {
+                stopBleScanWhileConnected();
                 LOG_INFO("AirPods already connected after wake-up, re-activating A2DP profile");
                 mediaController->setConnectedDeviceMacAddress(
                     m_deviceInfo->bluetoothAddress().replace(":", "_"));
@@ -681,6 +693,10 @@ public slots:
                     mediaController->activateA2dpProfile();
                     LOG_INFO("A2DP profile activation attempted after system wake-up");
                 });
+            }
+            else
+            {
+                m_bleManager->startScan();
             }
 
             monitor->checkAlreadyConnectedDevices();
@@ -901,6 +917,7 @@ private slots:
         auto handleConnection = [this, localSocket]()
         {
             m_retryCount = 0;
+            stopBleScanWhileConnected();
             connect(localSocket, &QBluetoothSocket::readyRead, this, [this, localSocket]()
                     {
             QByteArray data = localSocket->readAll();
@@ -1035,14 +1052,11 @@ private slots:
             {
                 mediaController->activateA2dpProfile();
             }
-            // BLE scan stays running even after L2CAP metadata arrives.
-            // Apple's AAP only sends case battery when a pod is docked;
-            // BLE manufacturer-data broadcasts include case battery on
-            // every lid-open / lid-close event regardless of pod
-            // position. Keeping the scan alive feeds bleDeviceFound ->
-            // Battery::setCaseFromBle so the case row in PodsMenu
-            // updates live during lid events. Cost: continuous BLE
-            // passive scan; negligible CPU.
+            // The connected AAP path provides listening controls and pod
+            // battery state. Keep BLE discovery off while that link is live
+            // so it cannot contend with A2DP; onDeviceDisconnected restarts
+            // discovery for case/lid and disconnected battery updates.
+            stopBleScanWhileConnected();
             emit airPodsStatusChanged();
         }
         else if (data.startsWith(AirPodsPackets::OneBudANCMode::HEADER)) {
@@ -1292,17 +1306,13 @@ public:
         connectToPhone();
 
         m_deviceInfo->loadFromSettings(*m_settings);
-        // Always start BLE scan regardless of L2CAP connection state.
-        // BLE advertisements carry the case-battery nibble that the
-        // L2CAP/AAP path can't see while the case lid is closed
-        // (AAP sends Component::Case with status=Disconnected in that
-        // window). setCaseFromBle in the BLE callback refreshes the
-        // case row in PodsMenu without needing the user to open the
-        // lid. Previous behavior gated scan on `!areAirpodsConnected()`
-        // so a daemon launched while pods were already in-ear would
-        // skip startScan entirely + the case battery would stay at
-        // unknown for the whole session.
-        m_bleManager->startScan();
+        // BLE advertisements remain useful while disconnected for case/lid
+        // and battery discovery. Once the AAP control link connects its
+        // handler stops this scan to protect active A2DP playback.
+        if (areAirpodsConnected())
+            stopBleScanWhileConnected();
+        else
+            m_bleManager->startScan();
     }
 
     // Null engine is the headless run, where there is no window to open and nothing to say about it.

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -698,6 +698,8 @@ public slots:
         // the disconnect notifications that BlueZ fires during resume
         // don't surface as user-visible "AirPods Disconnected" toasts.
         QTimer::singleShot(2000, this, [this]() {
+            m_bleManager->startScan();
+
             if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
             {
                 stopBleScanWhileConnected();
@@ -710,10 +712,6 @@ public slots:
                     mediaController->activateA2dpProfile();
                     LOG_INFO("A2DP profile activation attempted after system wake-up");
                 });
-            }
-            else
-            {
-                m_bleManager->startScan();
             }
 
             monitor->checkAlreadyConnectedDevices();

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -647,15 +647,32 @@ public slots:
     int loadRetryAttempts() const { return m_settings->value("bluetooth/retryAttempts", 3).toInt(); }
     void saveRetryAttempts(int attempts) { m_settings->setValue("bluetooth/retryAttempts", attempts); }
 
+    // Sample input: usb:v8087p0A2Bd0010dcE0dsc01dp01icE0isc01ip01in00
+    // Only Apple's own controller (vendor 05AC) drops A2DP packets under continuous BLE discovery.
+    static bool bluetoothControllerIsApple()
+    {
+        static const bool affected = []() {
+            QDir sys(QStringLiteral("/sys/class/bluetooth"));
+            const QStringList adapters = sys.entryList(QStringList() << QStringLiteral("hci*"),
+                                                       QDir::Dirs | QDir::NoDotAndDotDot);
+            for (const QString &adapter : adapters) {
+                QFile modalias(sys.filePath(adapter) + QStringLiteral("/device/modalias"));
+                if (!modalias.open(QIODevice::ReadOnly | QIODevice::Text))
+                    continue;
+                if (QString::fromLatin1(modalias.readAll()).contains(QStringLiteral("v05AC"), Qt::CaseInsensitive))
+                    return true;
+            }
+            return false;
+        }();
+        return affected;
+    }
+
     void stopBleScanWhileConnected()
     {
-        if (!areAirpodsConnected() || !m_bleManager->isScanning())
+        // Everywhere else keeps discovery running, so case and lid battery stay live while connected.
+        if (!bluetoothControllerIsApple() || !areAirpodsConnected() || !m_bleManager->isScanning())
             return;
 
-        // This controller carries A2DP and BLE on the same radio. Continuous
-        // discovery while audio is active coincides with malformed advertising
-        // reports and missing A2DP completion reports on this Broadcom
-        // controller, so favor uninterrupted audio once the AAP link is live.
         LOG_INFO("Stopping BLE scan while AirPods control link is connected");
         m_bleManager->stopScan();
     }
@@ -1052,10 +1069,7 @@ private slots:
             {
                 mediaController->activateA2dpProfile();
             }
-            // The connected AAP path provides listening controls and pod
-            // battery state. Keep BLE discovery off while that link is live
-            // so it cannot contend with A2DP; onDeviceDisconnected restarts
-            // discovery for case/lid and disconnected battery updates.
+            // Only on the affected controller, where onDeviceDisconnected restarts it.
             stopBleScanWhileConnected();
             emit airPodsStatusChanged();
         }
@@ -1306,12 +1320,8 @@ public:
         connectToPhone();
 
         m_deviceInfo->loadFromSettings(*m_settings);
-        // BLE advertisements remain useful while disconnected for case/lid
-        // and battery discovery. Once the AAP control link connects its
-        // handler stops this scan to protect active A2DP playback.
-        if (areAirpodsConnected())
-            stopBleScanWhileConnected();
-        else
+        // Nothing is scanning yet, so the affected controller is the only reason not to start.
+        if (!(areAirpodsConnected() && bluetoothControllerIsApple()))
             m_bleManager->startScan();
     }
 

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -698,6 +698,7 @@ public slots:
         // the disconnect notifications that BlueZ fires during resume
         // don't surface as user-visible "AirPods Disconnected" toasts.
         QTimer::singleShot(2000, this, [this]() {
+            // Suspend stopped discovery on every controller, so resume restarts it and the gate below re-applies.
             m_bleManager->startScan();
 
             if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -57,8 +57,12 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
     m_earOutPending = true;
     const quint64 generation = m_earDetectionGeneration;
     QTimer::singleShot(bothPodsOutSettleMs, this, [this, earDetection, generation]() {
+      // A superseded callback must not clear the window a newer report opened.
+      if (generation != m_earDetectionGeneration)
+        return;
+
       m_earOutPending = false;
-      if (generation != m_earDetectionGeneration || earDetectionBehavior == Disabled)
+      if (earDetectionBehavior == Disabled)
         return;
 
       if (earDetection->isPrimaryInEar() || earDetection->isSecondaryInEar())
@@ -73,6 +77,7 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
 
   // Any in-ear report supersedes a pending transient both-out report.
   ++m_earDetectionGeneration;
+  m_earOutPending = false;
 
   // First handle playback pausing based on selected behavior
   bool shouldPause = false;
@@ -98,22 +103,14 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
     }
   }
 
-  // Then handle device profile switching
-  if (primaryInEar || secondaryInEar)
-  {
-    LOG_DEBUG("At least one AirPod is in ear");
-    activateA2dpProfile();
+  // Then handle device profile switching, with both pods out already returned above
+  LOG_DEBUG("At least one AirPod is in ear");
+  activateA2dpProfile();
 
-    // Resume if conditions are met and we previously paused
-    if (shouldResume && !pausedByAppServices.isEmpty() && isActiveOutputDeviceAirPods())
-    {
-      play();
-    }
-  }
-  else
+  // Resume if conditions are met and we previously paused
+  if (shouldResume && !pausedByAppServices.isEmpty() && isActiveOutputDeviceAirPods())
   {
-    LOG_DEBUG("Both AirPods are out of ear");
-    removeAudioOutputDevice();
+    play();
   }
 }
 
@@ -127,6 +124,7 @@ void MediaController::setEarDetectionBehavior(EarDetectionBehavior behavior)
 
   // A pending both-out callback belongs to the policy that scheduled it, not to this one.
   ++m_earDetectionGeneration;
+  m_earOutPending = false;
   earDetectionBehavior = behavior;
   LOG_INFO("Set ear detection behavior to: " << behavior);
 }

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -13,6 +13,9 @@
 #include <QDBusConnectionInterface>
 #include <QTimer>
 
+// Long enough to outlast an ANC or transparency reconfigure, short enough not to strand playback.
+static constexpr int bothPodsOutSettleMs = 1200;
+
 MediaController::MediaController(QObject *parent) : QObject(parent) {
   m_pulseAudio = new PulseAudioController(this);
   if (!m_pulseAudio->initialize())
@@ -41,13 +44,20 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
   bool primaryInEar = earDetection->isPrimaryInEar();
   bool secondaryInEar = earDetection->isSecondaryInEar();
 
-  // ANC/transparency changes can briefly report both pods as out of ear while
-  // the AirPods reconfigure.  Do not tear down the Bluetooth audio card for
-  // that transient state; wait for it to persist before pausing/removing it.
+  LOG_DEBUG("Ear detection status: primaryInEar="
+            << primaryInEar << ", secondaryInEar=" << secondaryInEar
+            << ", isAirPodsActive=" << isActiveOutputDeviceAirPods());
+
+  // An ANC or transparency change reports both pods out for a moment while the AirPods reconfigure.
   if (!primaryInEar && !secondaryInEar)
   {
-    const quint64 generation = ++m_earDetectionGeneration;
-    QTimer::singleShot(1200, this, [this, earDetection, generation]() {
+    // Keep the first deadline, so a repeated both-out report cannot defer the teardown forever.
+    if (m_earOutPending)
+      return;
+    m_earOutPending = true;
+    const quint64 generation = m_earDetectionGeneration;
+    QTimer::singleShot(bothPodsOutSettleMs, this, [this, earDetection, generation]() {
+      m_earOutPending = false;
       if (generation != m_earDetectionGeneration || earDetectionBehavior == Disabled)
         return;
 
@@ -63,10 +73,6 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
 
   // Any in-ear report supersedes a pending transient both-out report.
   ++m_earDetectionGeneration;
-
-  LOG_DEBUG("Ear detection status: primaryInEar="
-            << primaryInEar << ", secondaryInEar=" << secondaryInEar
-            << ", isAirPodsActive=" << isActiveOutputDeviceAirPods());
 
   // First handle playback pausing based on selected behavior
   bool shouldPause = false;
@@ -119,9 +125,7 @@ void MediaController::setEarDetectionBehavior(EarDetectionBehavior behavior)
     return;
   }
 
-  // A delayed both-out callback belongs to the policy that scheduled it.
-  // Invalidate it before changing policy so disable/re-enable transitions
-  // cannot revive stale pause or output-removal work.
+  // A pending both-out callback belongs to the policy that scheduled it, not to this one.
   ++m_earDetectionGeneration;
   earDetectionBehavior = behavior;
   LOG_INFO("Set ear detection behavior to: " << behavior);
@@ -297,10 +301,7 @@ void MediaController::activateA2dpProfile() {
     return;
   }
 
-  // WirePlumber already owns profile negotiation.  Re-applying the same
-  // profile on every Bluetooth/AAP notification tears down the live sink and
-  // can interrupt active streams (and may race WirePlumber's codec setup).
-  // Only change the card when it is not already using the profile we chose.
+  // Re-applying the profile WirePlumber already set tears down the live sink under a playing stream.
   const QString activeProfile = m_pulseAudio->getActiveCardProfile(m_deviceOutputName);
   if (activeProfile == preferredProfile) {
     LOG_INFO("A2DP profile already active: " << activeProfile);

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -113,6 +113,16 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
 
 void MediaController::setEarDetectionBehavior(EarDetectionBehavior behavior)
 {
+  if (earDetectionBehavior == behavior)
+  {
+    LOG_DEBUG("Ear detection behavior is already set to: " << behavior);
+    return;
+  }
+
+  // A delayed both-out callback belongs to the policy that scheduled it.
+  // Invalidate it before changing policy so disable/re-enable transitions
+  // cannot revive stale pause or output-removal work.
+  ++m_earDetectionGeneration;
   earDetectionBehavior = behavior;
   LOG_INFO("Set ear detection behavior to: " << behavior);
 }

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -11,6 +11,7 @@
 #include <QRegularExpression>
 #include <QDBusConnection>
 #include <QDBusConnectionInterface>
+#include <QTimer>
 
 MediaController::MediaController(QObject *parent) : QObject(parent) {
   m_pulseAudio = new PulseAudioController(this);
@@ -39,6 +40,29 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
 
   bool primaryInEar = earDetection->isPrimaryInEar();
   bool secondaryInEar = earDetection->isSecondaryInEar();
+
+  // ANC/transparency changes can briefly report both pods as out of ear while
+  // the AirPods reconfigure.  Do not tear down the Bluetooth audio card for
+  // that transient state; wait for it to persist before pausing/removing it.
+  if (!primaryInEar && !secondaryInEar)
+  {
+    const quint64 generation = ++m_earDetectionGeneration;
+    QTimer::singleShot(1200, this, [this, earDetection, generation]() {
+      if (generation != m_earDetectionGeneration || earDetectionBehavior == Disabled)
+        return;
+
+      if (earDetection->isPrimaryInEar() || earDetection->isSecondaryInEar())
+        return;
+
+      if (isActiveOutputDeviceAirPods() && getCurrentMediaState() == Playing)
+        pause();
+      removeAudioOutputDevice();
+    });
+    return;
+  }
+
+  // Any in-ear report supersedes a pending transient both-out report.
+  ++m_earDetectionGeneration;
 
   LOG_DEBUG("Ear detection status: primaryInEar="
             << primaryInEar << ", secondaryInEar=" << secondaryInEar
@@ -263,12 +287,21 @@ void MediaController::activateA2dpProfile() {
     return;
   }
 
-  LOG_INFO("Activating best output profile: " << preferredProfile);
-  if (!m_pulseAudio->setCardProfile(m_deviceOutputName, preferredProfile)) {
-    LOG_ERROR("Failed to activate profile: " << preferredProfile);
-    return;
+  // WirePlumber already owns profile negotiation.  Re-applying the same
+  // profile on every Bluetooth/AAP notification tears down the live sink and
+  // can interrupt active streams (and may race WirePlumber's codec setup).
+  // Only change the card when it is not already using the profile we chose.
+  const QString activeProfile = m_pulseAudio->getActiveCardProfile(m_deviceOutputName);
+  if (activeProfile == preferredProfile) {
+    LOG_INFO("A2DP profile already active: " << activeProfile);
+  } else {
+    LOG_INFO("Activating best output profile: " << preferredProfile);
+    if (!m_pulseAudio->setCardProfile(m_deviceOutputName, preferredProfile)) {
+      LOG_ERROR("Failed to activate profile: " << preferredProfile);
+      return;
+    }
+    LOG_INFO("Profile activated: " << preferredProfile);
   }
-  LOG_INFO("Profile activated: " << preferredProfile);
 
   // After A2DP activation the AirPods sink is live + selected as
   // default. Enable AVRCP 5%-grid snap on it now. AirPods stem-

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -66,6 +66,7 @@ private:
   PlayerStatusWatcher *playerStatusWatcher = nullptr;
   PulseAudioController *m_pulseAudio = nullptr;
   QString m_cachedA2dpProfile;
+  quint64 m_earDetectionGeneration = 0;
 };
 
 #endif // MEDIACONTROLLER_H

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -67,6 +67,7 @@ private:
   PulseAudioController *m_pulseAudio = nullptr;
   QString m_cachedA2dpProfile;
   quint64 m_earDetectionGeneration = 0;
+  bool m_earOutPending = false;
 };
 
 #endif // MEDIACONTROLLER_H


### PR DESCRIPTION
Closes #3

## What changed

- avoid reapplying the selected A2DP profile when it is already active;
- debounce transient both-buds-out reports for 1.2 seconds before pausing or removing the audio output;
- stop continuous BLE discovery while the AirPods AAP/L2CAP control connection is active;
- keep BLE discovery stopped after metadata updates and suspend/resume;
- retain the existing disconnected scan path for case, lid, and battery discovery.

## Why

The daemon could disturb an existing A2DP stream through three separate paths:

1. reapplying the same card profile recreated the live sink;
2. ANC/transparency transitions could briefly look like both buds were out of ear;
3. endless Qt BLE discovery shared the Broadcom controller with A2DP and coincided with malformed advertisement reports and missing packet completion reports.

The BLE policy is intentionally audio-first. Case battery and lid changes may remain stale while the control/audio link is connected, then resume updating after disconnect.

## Validation

- `cmake --build build --parallel $(nproc)`
- `ctest --test-dir build --output-on-failure`: **15/15 passed**
- rebuilt daemon installed and exercised live;
- Spotify sink-input ID remained unchanged across daemon restart;
- both Spotify channels remained active;
- BlueZ remained `Discovering: no` while connected;
- zero malformed-advertisement warnings after restart;
- zero missing A2DP completion warnings;
- completed ANC ↔ Transparency, Conversation Awareness off/on, one-bud ANC off/on, and repeated panel open/close transitions;
- final state restored to Transparency, Conversation Awareness on, and one-bud ANC off.

## Tested hardware

MacBook Pro 13-inch 2017, two Thunderbolt 3 ports (A1708 / `MacBookPro14,1`):

- Intel Core i5-7360U
- Intel Iris Plus Graphics 640
- 8 GB RAM (7.62 GiB usable)
- Broadcom BCM4350C0 UART Bluetooth
- Omarchy 4.0.0-1
- Linux 7.1.8-arch1-3
- BlueZ 5.87-2
- PipeWire 1.6.8-1
- WirePlumber 0.5.15-1
- Qt Connectivity 6.11.1-1
- AirPods Pro 3 (A3064)

The complete Fastfetch output and before/after diagnostics are recorded in #3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added headset battery status and headset identification to status information.
* **Bug Fixes**
  * Improved Bluetooth scanning behavior while AirPods are connected and after disconnection.
  * Prevented playback pauses or device removal during brief, inconsistent out-of-ear reports.
  * Ignored ear-detection events when disabled.
  * Avoided unnecessary audio profile reactivation and redundant behavior updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->