### PR TITLE
Fix AirPods never being set as audio output (A2DP activation race)

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -148,9 +148,8 @@ public:
                 QTimer::singleShot(2000, this, [this, address]()
                 {
                     QString formattedAddress = address.toString().replace(":", "_");
-                    mediaController->setConnectedDeviceMacAddress(formattedAddress);
-                    mediaController->activateA2dpProfile();
                     LOG_INFO("A2DP profile activation attempted for AirPods found on startup");
+                    activateA2dpProfileWithRetry(formattedAddress);
                 });
                 return;
             }
@@ -245,6 +244,37 @@ private:
 
     void disconnectDevice(const QString &devicePath) {
         LOG_INFO("Disconnecting device at " << devicePath);
+    }
+
+    // PipeWire/WirePlumber publish the bluez5 card for a freshly-connected
+    // device asynchronously, on no fixed schedule — a single delayed
+    // attempt can fire before the card exists, silently leaving the
+    // AirPods stuck on the "off" profile (mic-only via headset-head-unit,
+    // no output sink). Poll with backoff instead of a one-shot timer.
+    void activateA2dpProfileWithRetry(const QString &formattedAddress, int attempt = 0)
+    {
+        static constexpr int kMaxAttempts = 6;
+        static constexpr int kDelayMs = 1500;
+
+        if (formattedAddress.isEmpty() || !mediaController) return;
+
+        mediaController->setConnectedDeviceMacAddress(formattedAddress);
+        if (mediaController->activateA2dpProfile())
+        {
+            LOG_INFO("A2DP profile activated (attempt " << (attempt + 1) << ")");
+            return;
+        }
+
+        if (attempt + 1 >= kMaxAttempts)
+        {
+            LOG_ERROR("Giving up on A2DP profile activation after " << kMaxAttempts << " attempts");
+            return;
+        }
+
+        QTimer::singleShot(kDelayMs, this, [this, formattedAddress, attempt]()
+        {
+            activateA2dpProfileWithRetry(formattedAddress, attempt + 1);
+        });
     }
 
 public slots:
@@ -705,13 +735,10 @@ public slots:
             {
                 stopBleScanWhileConnected();
                 LOG_INFO("AirPods already connected after wake-up, re-activating A2DP profile");
-                mediaController->setConnectedDeviceMacAddress(
-                    m_deviceInfo->bluetoothAddress().replace(":", "_"));
-
                 // Profile may have been dropped during suspend; reassert.
                 QTimer::singleShot(1000, this, [this]() {
-                    mediaController->activateA2dpProfile();
                     LOG_INFO("A2DP profile activation attempted after system wake-up");
+                    activateA2dpProfileWithRetry(m_deviceInfo->bluetoothAddress().replace(":", "_"));
                 });
             }
 
@@ -788,9 +815,8 @@ private slots:
             {
                 QString formattedAddress = address;
                 formattedAddress = formattedAddress.replace(":", "_");
-                mediaController->setConnectedDeviceMacAddress(formattedAddress);
-                mediaController->activateA2dpProfile();
                 LOG_INFO("A2DP profile activation attempted for newly connected device");
+                activateA2dpProfileWithRetry(formattedAddress);
             }
         });
     }
@@ -1063,10 +1089,13 @@ private slots:
         {
             parseMetadata(data);
             initiateMagicPairing();
-            mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress().replace(":", "_"));
             if (m_deviceInfo->getEarDetection()->oneOrMorePodsInEar()) // AirPods get added as output device only after this
             {
-                mediaController->activateA2dpProfile();
+                activateA2dpProfileWithRetry(m_deviceInfo->bluetoothAddress().replace(":", "_"));
+            }
+            else
+            {
+                mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress().replace(":", "_"));
             }
             // Only on the affected controller, where onDeviceDisconnected restarts it.
             stopBleScanWhileConnected();

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -149,7 +149,10 @@ public:
                 {
                     // A disconnect inside these two seconds would otherwise start a chain for a device that left.
                     if (!areAirpodsConnected())
+                    {
+                        LOG_INFO("AirPods disconnected before the startup A2DP activation, skipping it");
                         return;
+                    }
 
                     QString formattedAddress = address.toString().replace(":", "_");
                     LOG_INFO("A2DP profile activation attempted for AirPods found on startup");

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -147,6 +147,10 @@ public:
                 // On startup after reboot, activate A2DP profile for already connected AirPods
                 QTimer::singleShot(2000, this, [this, address]()
                 {
+                    // A disconnect inside these two seconds would otherwise start a chain for a device that left.
+                    if (!areAirpodsConnected())
+                        return;
+
                     QString formattedAddress = address.toString().replace(":", "_");
                     LOG_INFO("A2DP profile activation attempted for AirPods found on startup");
                     mediaController->activateA2dpProfileWithRetry(formattedAddress);
@@ -793,12 +797,8 @@ private slots:
     void onDeviceDisconnected(const QBluetoothAddress &address)
     {
         LOG_INFO("Device disconnected: " << address.toString());
-        // A retry queued by an in-flight A2DP activation chain must not
-        // fire after this disconnect and restore/reactivate a profile for
-        // a device that just went away.
-        if (mediaController) {
-            mediaController->cancelPendingA2dpActivation();
-        }
+        // A retry still in flight would reactivate a profile for the device that just went away.
+        mediaController->cancelPendingA2dpActivation();
         if (socket)
         {
             LOG_WARN("Socket is still open, closing it");

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -149,7 +149,7 @@ public:
                 {
                     QString formattedAddress = address.toString().replace(":", "_");
                     LOG_INFO("A2DP profile activation attempted for AirPods found on startup");
-                    activateA2dpProfileWithRetry(formattedAddress);
+                    mediaController->activateA2dpProfileWithRetry(formattedAddress);
                 });
                 return;
             }
@@ -244,37 +244,6 @@ private:
 
     void disconnectDevice(const QString &devicePath) {
         LOG_INFO("Disconnecting device at " << devicePath);
-    }
-
-    // PipeWire/WirePlumber publish the bluez5 card for a freshly-connected
-    // device asynchronously, on no fixed schedule — a single delayed
-    // attempt can fire before the card exists, silently leaving the
-    // AirPods stuck on the "off" profile (mic-only via headset-head-unit,
-    // no output sink). Poll with backoff instead of a one-shot timer.
-    void activateA2dpProfileWithRetry(const QString &formattedAddress, int attempt = 0)
-    {
-        static constexpr int kMaxAttempts = 6;
-        static constexpr int kDelayMs = 1500;
-
-        if (formattedAddress.isEmpty() || !mediaController) return;
-
-        mediaController->setConnectedDeviceMacAddress(formattedAddress);
-        if (mediaController->activateA2dpProfile())
-        {
-            LOG_INFO("A2DP profile activated (attempt " << (attempt + 1) << ")");
-            return;
-        }
-
-        if (attempt + 1 >= kMaxAttempts)
-        {
-            LOG_ERROR("Giving up on A2DP profile activation after " << kMaxAttempts << " attempts");
-            return;
-        }
-
-        QTimer::singleShot(kDelayMs, this, [this, formattedAddress, attempt]()
-        {
-            activateA2dpProfileWithRetry(formattedAddress, attempt + 1);
-        });
     }
 
 public slots:
@@ -738,7 +707,7 @@ public slots:
                 // Profile may have been dropped during suspend; reassert.
                 QTimer::singleShot(1000, this, [this]() {
                     LOG_INFO("A2DP profile activation attempted after system wake-up");
-                    activateA2dpProfileWithRetry(m_deviceInfo->bluetoothAddress().replace(":", "_"));
+                    mediaController->activateA2dpProfileWithRetry(m_deviceInfo->bluetoothAddress().replace(":", "_"));
                 });
             }
 
@@ -816,7 +785,7 @@ private slots:
                 QString formattedAddress = address;
                 formattedAddress = formattedAddress.replace(":", "_");
                 LOG_INFO("A2DP profile activation attempted for newly connected device");
-                activateA2dpProfileWithRetry(formattedAddress);
+                mediaController->activateA2dpProfileWithRetry(formattedAddress);
             }
         });
     }
@@ -824,6 +793,12 @@ private slots:
     void onDeviceDisconnected(const QBluetoothAddress &address)
     {
         LOG_INFO("Device disconnected: " << address.toString());
+        // A retry queued by an in-flight A2DP activation chain must not
+        // fire after this disconnect and restore/reactivate a profile for
+        // a device that just went away.
+        if (mediaController) {
+            mediaController->cancelPendingA2dpActivation();
+        }
         if (socket)
         {
             LOG_WARN("Socket is still open, closing it");
@@ -1091,7 +1066,7 @@ private slots:
             initiateMagicPairing();
             if (m_deviceInfo->getEarDetection()->oneOrMorePodsInEar()) // AirPods get added as output device only after this
             {
-                activateA2dpProfileWithRetry(m_deviceInfo->bluetoothAddress().replace(":", "_"));
+                mediaController->activateA2dpProfileWithRetry(m_deviceInfo->bluetoothAddress().replace(":", "_"));
             }
             else
             {

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -105,7 +105,7 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
 
   // Then handle device profile switching, with both pods out already returned above
   LOG_DEBUG("At least one AirPod is in ear");
-  activateA2dpProfile();
+  activateA2dpProfileWithRetry(connectedDeviceMacAddress);
 
   // Resume if conditions are met and we previously paused
   if (shouldResume && !pausedByAppServices.isEmpty() && isActiveOutputDeviceAirPods())
@@ -330,17 +330,62 @@ bool MediaController::activateA2dpProfile() {
   return true;
 }
 
+void MediaController::activateA2dpProfileWithRetry(const QString &macAddress) {
+  if (macAddress.isEmpty()) return;
+
+  // A fresh generation supersedes any chain already in flight for a
+  // previous connect/wake/metadata event, so only the newest request's
+  // queued callbacks will still act.
+  const quint64 generation = ++m_a2dpRetryGeneration;
+  attemptA2dpActivation(macAddress, generation, 0);
+}
+
+void MediaController::cancelPendingA2dpActivation() {
+  ++m_a2dpRetryGeneration;
+}
+
+void MediaController::attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt) {
+  // Superseded by a newer activation request, or the device disconnected
+  // via cancelPendingA2dpActivation() -- don't restore a stale MAC address
+  // or reactivate a profile for a device that's no longer current.
+  if (generation != m_a2dpRetryGeneration) return;
+
+  // PipeWire/WirePlumber publish the bluez5 card for a freshly-connected
+  // device asynchronously, with no fixed timing guarantee, so the first
+  // attempt or two commonly fail with the card simply not existing yet.
+  setConnectedDeviceMacAddress(macAddress);
+  if (activateA2dpProfile()) {
+    LOG_INFO("A2DP profile activated (attempt " << (attempt + 1) << ")");
+    return;
+  }
+
+  static constexpr int kMaxAttempts = 6;
+  static constexpr int kDelayMs = 1500;
+  if (attempt + 1 >= kMaxAttempts) {
+    LOG_ERROR("Giving up on A2DP profile activation after " << kMaxAttempts << " attempts");
+    return;
+  }
+
+  QTimer::singleShot(kDelayMs, this, [this, macAddress, generation, attempt]() {
+    attemptA2dpActivation(macAddress, generation, attempt + 1);
+  });
+}
+
 QString MediaController::getActiveProfile() {
   if (m_deviceOutputName.isEmpty()) return QString();
   return m_pulseAudio->getActiveCardProfile(m_deviceOutputName);
 }
 
 void MediaController::removeAudioOutputDevice() {
+  // A retry queued by a still-in-flight activation chain must not
+  // resurrect the sink right after we tear it down here.
+  cancelPendingA2dpActivation();
+
   if (connectedDeviceMacAddress.isEmpty() || m_deviceOutputName.isEmpty()) {
     LOG_WARN("Connected device MAC address or output name is empty, cannot remove audio output device");
     return;
   }
-  
+
   LOG_INFO("Removing AirPods as audio output device");
   // Disable AVRCP volume snap before the sink goes away. Empty
   // sink-name argument disables the snap path inside

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -274,29 +274,20 @@ bool MediaController::restartWirePlumber() {
 }
 
 bool MediaController::activateA2dpProfile() {
-  return activateA2dpProfile(/*allowWirePlumberRestart=*/true);
-}
-
-bool MediaController::activateA2dpProfile(bool allowWirePlumberRestart) {
   if (connectedDeviceMacAddress.isEmpty() || m_deviceOutputName.isEmpty()) {
-    // Common right after connect: BlueZ has the device but PipeWire/
-    // WirePlumber hasn't published the bluez5 card object yet. This is
-    // not fatal — callers retry on false, re-resolving the card name
-    // via setConnectedDeviceMacAddress() on the next attempt.
+    // Usual right after connect, PipeWire has not published the bluez5 card yet, and callers retry.
     LOG_WARN("Connected device MAC address or output name is empty, cannot activate A2DP profile");
     return false;
   }
 
   if (!isA2dpProfileAvailable()) {
-    if (!allowWirePlumberRestart) {
-      // Already restarted WirePlumber once for this retry chain (see
-      // attemptA2dpActivation). Restarting again on every subsequent
-      // attempt would block this thread for ~2s each time without the
-      // card having had a chance to settle in between.
-      LOG_WARN("A2DP profile still not available, not restarting WirePlumber again this chain");
+    // A restart blocks this thread for about 2s, so a chain gets one however many attempts it takes.
+    if (m_wirePlumberRestartedThisChain) {
+      LOG_WARN("A2DP profile still not available, WirePlumber was already restarted for this chain");
       return false;
     }
     LOG_WARN("A2DP profile not available, attempting to restart WirePlumber");
+    m_wirePlumberRestartedThisChain = true;
     if (restartWirePlumber()) {
       m_deviceOutputName = getAudioDeviceName();
       if (!isA2dpProfileAvailable()) {
@@ -343,12 +334,14 @@ bool MediaController::activateA2dpProfile(bool allowWirePlumberRestart) {
 }
 
 void MediaController::activateA2dpProfileWithRetry(const QString &macAddress) {
-  if (macAddress.isEmpty()) return;
+  if (macAddress.isEmpty()) {
+    LOG_WARN("No MAC address for the connected device, cannot start A2DP profile activation");
+    return;
+  }
 
-  // A fresh generation supersedes any chain already in flight for a
-  // previous connect/wake/metadata event, so only the newest request's
-  // queued callbacks will still act.
+  // A fresh generation supersedes any chain still in flight, so only the newest request acts.
   const quint64 generation = ++m_a2dpRetryGeneration;
+  m_wirePlumberRestartedThisChain = false;
   attemptA2dpActivation(macAddress, generation, 0);
 }
 
@@ -357,19 +350,12 @@ void MediaController::cancelPendingA2dpActivation() {
 }
 
 void MediaController::attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt) {
-  // Superseded by a newer activation request, or the device disconnected
-  // via cancelPendingA2dpActivation() -- don't restore a stale MAC address
-  // or reactivate a profile for a device that's no longer current.
+  // A newer request or a disconnect superseded this chain, so it must not restore a stale device.
   if (generation != m_a2dpRetryGeneration) return;
 
-  // PipeWire/WirePlumber publish the bluez5 card for a freshly-connected
-  // device asynchronously, with no fixed timing guarantee, so the first
-  // attempt or two commonly fail with the card simply not existing yet.
-  // A WirePlumber restart (see activateA2dpProfile) blocks this thread
-  // for ~2s, so only the first attempt in a chain is allowed to trigger
-  // one; later attempts just re-resolve and re-check.
+  // PipeWire publishes the bluez5 card asynchronously, so the first attempts commonly find nothing.
   setConnectedDeviceMacAddress(macAddress);
-  if (activateA2dpProfile(/*allowWirePlumberRestart=*/attempt == 0)) {
+  if (activateA2dpProfile()) {
     LOG_INFO("A2DP profile activated (attempt " << (attempt + 1) << ")");
     return;
   }
@@ -392,8 +378,7 @@ QString MediaController::getActiveProfile() {
 }
 
 void MediaController::removeAudioOutputDevice() {
-  // A retry queued by a still-in-flight activation chain must not
-  // resurrect the sink right after we tear it down here.
+  // A retry still in flight would resurrect the sink right after this tears it down.
   cancelPendingA2dpActivation();
 
   if (connectedDeviceMacAddress.isEmpty() || m_deviceOutputName.isEmpty()) {

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -274,6 +274,10 @@ bool MediaController::restartWirePlumber() {
 }
 
 bool MediaController::activateA2dpProfile() {
+  return activateA2dpProfile(/*allowWirePlumberRestart=*/true);
+}
+
+bool MediaController::activateA2dpProfile(bool allowWirePlumberRestart) {
   if (connectedDeviceMacAddress.isEmpty() || m_deviceOutputName.isEmpty()) {
     // Common right after connect: BlueZ has the device but PipeWire/
     // WirePlumber hasn't published the bluez5 card object yet. This is
@@ -284,6 +288,14 @@ bool MediaController::activateA2dpProfile() {
   }
 
   if (!isA2dpProfileAvailable()) {
+    if (!allowWirePlumberRestart) {
+      // Already restarted WirePlumber once for this retry chain (see
+      // attemptA2dpActivation). Restarting again on every subsequent
+      // attempt would block this thread for ~2s each time without the
+      // card having had a chance to settle in between.
+      LOG_WARN("A2DP profile still not available, not restarting WirePlumber again this chain");
+      return false;
+    }
     LOG_WARN("A2DP profile not available, attempting to restart WirePlumber");
     if (restartWirePlumber()) {
       m_deviceOutputName = getAudioDeviceName();
@@ -353,8 +365,11 @@ void MediaController::attemptA2dpActivation(const QString &macAddress, quint64 g
   // PipeWire/WirePlumber publish the bluez5 card for a freshly-connected
   // device asynchronously, with no fixed timing guarantee, so the first
   // attempt or two commonly fail with the card simply not existing yet.
+  // A WirePlumber restart (see activateA2dpProfile) blocks this thread
+  // for ~2s, so only the first attempt in a chain is allowed to trigger
+  // one; later attempts just re-resolve and re-check.
   setConnectedDeviceMacAddress(macAddress);
-  if (activateA2dpProfile()) {
+  if (activateA2dpProfile(/*allowWirePlumberRestart=*/attempt == 0)) {
     LOG_INFO("A2DP profile activated (attempt " << (attempt + 1) << ")");
     return;
   }

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -273,10 +273,14 @@ bool MediaController::restartWirePlumber() {
   }
 }
 
-void MediaController::activateA2dpProfile() {
+bool MediaController::activateA2dpProfile() {
   if (connectedDeviceMacAddress.isEmpty() || m_deviceOutputName.isEmpty()) {
+    // Common right after connect: BlueZ has the device but PipeWire/
+    // WirePlumber hasn't published the bluez5 card object yet. This is
+    // not fatal — callers retry on false, re-resolving the card name
+    // via setConnectedDeviceMacAddress() on the next attempt.
     LOG_WARN("Connected device MAC address or output name is empty, cannot activate A2DP profile");
-    return;
+    return false;
   }
 
   if (!isA2dpProfileAvailable()) {
@@ -285,18 +289,18 @@ void MediaController::activateA2dpProfile() {
       m_deviceOutputName = getAudioDeviceName();
       if (!isA2dpProfileAvailable()) {
         LOG_ERROR("A2DP profile still not available after WirePlumber restart");
-        return;
+        return false;
       }
     } else {
       LOG_ERROR("Could not restart WirePlumber, A2DP profile unavailable");
-      return;
+      return false;
     }
   }
 
   QString preferredProfile = getPreferredA2dpProfile();
   if (preferredProfile.isEmpty()) {
     LOG_ERROR("No suitable A2DP profile found");
-    return;
+    return false;
   }
 
   // Re-applying the profile WirePlumber already set tears down the live sink under a playing stream.
@@ -307,7 +311,7 @@ void MediaController::activateA2dpProfile() {
     LOG_INFO("Activating best output profile: " << preferredProfile);
     if (!m_pulseAudio->setCardProfile(m_deviceOutputName, preferredProfile)) {
       LOG_ERROR("Failed to activate profile: " << preferredProfile);
-      return;
+      return false;
     }
     LOG_INFO("Profile activated: " << preferredProfile);
   }
@@ -322,6 +326,8 @@ void MediaController::activateA2dpProfile() {
   if (!sink.isEmpty() && sink.contains(connectedDeviceMacAddress)) {
     m_pulseAudio->enableVolumeSnap(sink, 5);
   }
+
+  return true;
 }
 
 QString MediaController::getActiveProfile() {

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -35,7 +35,7 @@ public:
   void followMediaChanges();
   bool isActiveOutputDeviceAirPods();
   void handleConversationalAwareness(const QByteArray &data);
-  void activateA2dpProfile();
+  bool activateA2dpProfile();
   void removeAudioOutputDevice();
   void setConnectedDeviceMacAddress(const QString &macAddress);
   bool isA2dpProfileAvailable();

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -59,7 +59,6 @@ private:
   MediaState mediaStateFromPlayerctlOutput(const QString &output) const;
   QString getAudioDeviceName();
   QStringList getPlayingMediaPlayers();
-  bool activateA2dpProfile(bool allowWirePlumberRestart);
   void attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt);
 
   QStringList pausedByAppServices;
@@ -72,13 +71,9 @@ private:
   QString m_cachedA2dpProfile;
   quint64 m_earDetectionGeneration = 0;
   bool m_earOutPending = false;
-  // Bumped on every new activateA2dpProfileWithRetry() call and on
-  // cancelPendingA2dpActivation(). A queued retry callback compares its
-  // captured generation against this before acting, so a chain started
-  // before a disconnect (or superseded by a newer connect) can't restore
-  // a stale MAC address or reactivate a profile for a device that's no
-  // longer current.
+  // A queued retry compares its captured generation against this, so a superseded chain stops.
   quint64 m_a2dpRetryGeneration = 0;
+  bool m_wirePlumberRestartedThisChain = false;
 };
 
 #endif // MEDIACONTROLLER_H

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -59,6 +59,7 @@ private:
   MediaState mediaStateFromPlayerctlOutput(const QString &output) const;
   QString getAudioDeviceName();
   QStringList getPlayingMediaPlayers();
+  bool activateA2dpProfile(bool allowWirePlumberRestart);
   void attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt);
 
   QStringList pausedByAppServices;

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -36,6 +36,8 @@ public:
   bool isActiveOutputDeviceAirPods();
   void handleConversationalAwareness(const QByteArray &data);
   bool activateA2dpProfile();
+  void activateA2dpProfileWithRetry(const QString &macAddress);
+  void cancelPendingA2dpActivation();
   void removeAudioOutputDevice();
   void setConnectedDeviceMacAddress(const QString &macAddress);
   bool isA2dpProfileAvailable();
@@ -57,6 +59,7 @@ private:
   MediaState mediaStateFromPlayerctlOutput(const QString &output) const;
   QString getAudioDeviceName();
   QStringList getPlayingMediaPlayers();
+  void attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt);
 
   QStringList pausedByAppServices;
   int initialVolume = -1;
@@ -68,6 +71,13 @@ private:
   QString m_cachedA2dpProfile;
   quint64 m_earDetectionGeneration = 0;
   bool m_earOutPending = false;
+  // Bumped on every new activateA2dpProfileWithRetry() call and on
+  // cancelPendingA2dpActivation(). A queued retry callback compares its
+  // captured generation against this before acting, so a chain started
+  // before a disconnect (or superseded by a newer connect) can't restore
+  // a stale MAC address or reactivate a profile for a device that's no
+  // longer current.
+  quint64 m_a2dpRetryGeneration = 0;
 };
 
 #endif // MEDIACONTROLLER_H

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -35,7 +35,6 @@ public:
   void followMediaChanges();
   bool isActiveOutputDeviceAirPods();
   void handleConversationalAwareness(const QByteArray &data);
-  bool activateA2dpProfile();
   void activateA2dpProfileWithRetry(const QString &macAddress);
   void cancelPendingA2dpActivation();
   void removeAudioOutputDevice();
@@ -59,6 +58,8 @@ private:
   MediaState mediaStateFromPlayerctlOutput(const QString &output) const;
   QString getAudioDeviceName();
   QStringList getPlayingMediaPlayers();
+  // Only the retry chain calls this, so the one-restart flag below cannot be read outside a chain.
+  bool activateA2dpProfile();
   void attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt);
 
   QStringList pausedByAppServices;


### PR DESCRIPTION
## What changed

`activateA2dpProfile()` now returns `bool` instead of `void`, and all
four call sites that activate the A2DP profile after a connect/wake
event route through a new `activateA2dpProfileWithRetry()` helper that
retries with a 1.5s delay, up to 6 attempts (~9s), before giving up.

## Why

PipeWire/WirePlumber publish the `bluez5` card for a freshly-connected
Bluetooth device asynchronously, with no fixed timing guarantee. Every
existing call site fired a **single** attempt at activating A2DP (a
one-shot timer, or an immediate call on AAP metadata arrival) and gave
up silently if `getCardNameForDevice()` didn't find the card yet.

When that race is lost, the AirPods stay on the `off` PulseAudio/PipeWire
profile — no output sink is ever created, so the AirPods never show up
in the system audio panel as an output device, even though they're
fully connected and paired. Only the mic-capable `headset-head-unit`
profile is reachable at that point (which is why they can still work
as an *input*).

## Reproduction

Confirmed live with an AirPods Pro 3 (A3063): after a disconnect +
reconnect (both via `bluetoothctl` and via the Omarchy Bluetooth
panel), the daemon log consistently showed:

```
No matching Bluetooth card found for MAC address: "xx_xx_xx_xx_xx_xx"
Connected device MAC address or output name is empty, cannot activate A2DP profile
No matching Bluetooth card found for MAC address: "xx_xx_xx_xx_xx_xx"
Connected device MAC address or output name is empty, cannot activate A2DP profile
...
Device output name set to: "bluez_card.xx_xx_xx_xx_xx_xx"
Profile activated: "a2dp-sink-sbc_xq"
```

i.e. the card genuinely doesn't exist yet for the first ~2-4 seconds
after connect. With the previous single-attempt code this meant a
coin-flip whether A2DP ever activated for a given connection.

## Testing

- `cmake --build build --parallel $(nproc)`: clean build
- `ctest --test-dir build --output-on-failure`: **15/15 passed**
- Rebuilt daemon installed via `~/.local/bin/librepods`, exercised live
  against real AirPods Pro 3 hardware:
  - Repeated disconnect/reconnect via `bluetoothctl`: A2DP consistently
    activated within 2-3 retry attempts, sink appeared as default output,
    stayed active (including through actual audio playback) for 100+s
    with no reversion.
  - Repeated disconnect/reconnect via the Omarchy Bluetooth panel UI:
    same result — AirPods correctly appeared as an output device in the
    system audio panel afterward.

## Note for maintainers

This touches the same functions as #4 (`activateA2dpProfile()` in
`mediacontroller.cpp`/`.h`, and the same `main.cpp` call sites around
wake-up / BlueZ-connect / AAP-metadata). The two changes are
complementary — #4 avoids reapplying an already-active profile and
stops BLE scanning from contending with the A2DP radio; this PR adds
retry/backoff for the case where the profile was never applied in
the first place because the PipeWire card didn't exist yet. Whichever
merges second will need a small rebase, but there's no logical
conflict between the two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved A2DP profile activation reliability with automatic retries during startup, wake-up, and device connection.
  * Activation now reports success or failure when devices or profiles are unavailable.
  * Pending activation attempts are canceled when a device disconnects.
  * Delayed earbud removal handling prevents transient disconnects from immediately removing the device.
  * BLE scanning is managed more reliably during connections.
  * Headset battery information is now included in status data, with clearer headset identification.
  * A2DP activation remains limited to cases where an in-ear pod is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->