### PR TITLE
Make first install one command and document the hidden icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ omarchy pkg add cmake ninja qt6-connectivity qt6-tools qt6-declarative pkgconf l
 cd ~/.config/omarchy/plugins/io.github.thisisgm.omapods/daemon
 cmake -B build -G Ninja -DBUILD_TESTING=OFF && cmake --build build
 cmake --install build --prefix ~/.local
+systemctl --user daemon-reload
 systemctl --user enable librepods.service
 systemctl --user restart librepods.service
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@
   package built from it carry no state file, no `status` verb, none of the
   `ca:`, `onebud:` or `adaptive:` verbs, and no AirPods Pro 3 model map, so the
   panel would stay hidden forever. See [daemon/UPSTREAM.md](daemon/UPSTREAM.md)
-  for what it is, who wrote it and what was changed. Install builds it.
+  for what it is, who wrote it and what was changed. `omarchy plugin add` only
+  clones the plugin; `setup` builds the daemon.
 - AirPods paired to the machine through the usual Bluetooth flow.
 
 ## How it works
@@ -73,17 +74,26 @@ empty surface.
 
 ```bash
 omarchy plugin add https://github.com/thisisgm/omarchy-pods --enable
-omarchy bar move io.github.thisisgm.omapods
+~/.config/omarchy/plugins/io.github.thisisgm.omapods/setup
 ```
 
-The [marketplace listing](https://omarchyplugins.com/plugin.html?id=io.github.thisisgm.omapods)
+`--enable` already places the widget on the right of the bar. The
+[marketplace listing](https://omarchyplugins.com/plugin.html?id=io.github.thisisgm.omapods)
 installs to the same place.
 
-Then build the daemon out of the copy that just cloned, and hand it to systemd.
-Building it needs `cmake`, `ninja`, `qt6-connectivity`, `qt6-tools`,
-`qt6-declarative`, `pkgconf` and `libpulse`:
+`setup` installs `cmake`, `ninja`, `qt6-connectivity`, `qt6-tools`,
+`qt6-declarative`, `pkgconf` and `libpulse` if they are missing, builds the
+daemon into `~/.local`, and enables `librepods.service`. The icon stays hidden
+until AirPods are connected (`hideWhenDisconnected`). To keep it visible:
 
 ```bash
+omarchy bar set io.github.thisisgm.omapods hideWhenDisconnected false --json
+```
+
+To build the daemon by hand instead of running `setup`:
+
+```bash
+omarchy pkg add cmake ninja qt6-connectivity qt6-tools qt6-declarative pkgconf libpulse
 cd ~/.config/omarchy/plugins/io.github.thisisgm.omapods/daemon
 cmake -B build -G Ninja && cmake --build build
 cmake --install build --prefix ~/.local

--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ To build the daemon by hand instead of running `setup`:
 ```bash
 omarchy pkg add cmake ninja qt6-connectivity qt6-tools qt6-declarative pkgconf libpulse
 cd ~/.config/omarchy/plugins/io.github.thisisgm.omapods/daemon
-cmake -B build -G Ninja && cmake --build build
+cmake -B build -G Ninja -DBUILD_TESTING=OFF && cmake --build build
 cmake --install build --prefix ~/.local
-systemctl --user enable --now librepods.service
+systemctl --user enable librepods.service
+systemctl --user restart librepods.service
 ```
 
 `~/.local` is the prefix the unit expects, because it runs

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -123,8 +123,9 @@ qt_add_translations(librepods
 install(FILES ${QM_FILES}
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/openpods/translations")
 
-# Unit tests — opt-in via BUILD_TESTING. CTest is what defines that option and
-# defaults it ON; without this include the whole suite silently never builds.
+# CTest defaults BUILD_TESTING ON. A user cmake from the README should not
+# compile the Qt Test suite unless they asked.
+option(BUILD_TESTING "Build unit tests" OFF)
 include(CTest)
 if(BUILD_TESTING)
     enable_testing()

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -123,9 +123,7 @@ qt_add_translations(librepods
 install(FILES ${QM_FILES}
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/openpods/translations")
 
-# CTest defaults BUILD_TESTING ON. A user cmake from the README should not
-# compile the Qt Test suite unless they asked.
-option(BUILD_TESTING "Build unit tests" OFF)
+# CTest defines BUILD_TESTING and defaults it ON, so without this include the suite never builds.
 include(CTest)
 if(BUILD_TESTING)
     enable_testing()

--- a/setup
+++ b/setup
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Install build packages, compile the daemon, and enable the user service.
+# omarchy plugin add only clones files; this is the rest of install.
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")" && pwd)
+daemon="$root/daemon"
+prefix="${PREFIX:-$HOME/.local}"
+
+omarchy pkg add cmake ninja qt6-connectivity qt6-tools qt6-declarative pkgconf libpulse
+
+cmake -S "$daemon" -B "$daemon/build" -G Ninja -DBUILD_TESTING=OFF
+cmake --build "$daemon/build"
+cmake --install "$daemon/build" --prefix "$prefix"
+systemctl --user daemon-reload
+systemctl --user enable --now librepods.service
+
+echo "librepods is running."
+echo "The bar icon stays hidden until AirPods are connected."
+echo "Keep it visible: omarchy bar set io.github.thisisgm.omapods hideWhenDisconnected false --json"

--- a/setup
+++ b/setup
@@ -1,20 +1,20 @@
 #!/bin/bash
-# Install build packages, compile the daemon, and enable the user service.
-# omarchy plugin add only clones files; this is the rest of install.
+# omarchy plugin add only clones files, so this is the rest of the install.
 
 set -euo pipefail
 
 root=$(cd "$(dirname "$0")" && pwd)
 daemon="$root/daemon"
-prefix="${PREFIX:-$HOME/.local}"
 
 omarchy pkg add cmake ninja qt6-connectivity qt6-tools qt6-declarative pkgconf libpulse
 
 cmake -S "$daemon" -B "$daemon/build" -G Ninja -DBUILD_TESTING=OFF
 cmake --build "$daemon/build"
-cmake --install "$daemon/build" --prefix "$prefix"
+cmake --install "$daemon/build" --prefix "$HOME/.local"
 systemctl --user daemon-reload
-systemctl --user enable --now librepods.service
+systemctl --user enable librepods.service
+# enable --now would leave an already-running daemon on the old binary after an update.
+systemctl --user restart librepods.service
 
 echo "librepods is running."
 echo "The bar icon stays hidden until AirPods are connected."


### PR DESCRIPTION
A first install following the README left the daemon unbuilt and the bar empty.

**Not in the README**
- `omarchy plugin add` only clones files. It does not build the daemon.
- Build packages were listed but never installed. A stock Omarchy box was missing `qt6-connectivity` and `qt6-tools`.
- `omarchy bar move` with no placement is a no-op. `--enable` already puts the widget on the right.
- `hideWhenDisconnected` defaults on, so a successful install shows nothing until AirPods connect.

**Automated**
- `setup` installs the packages, builds the daemon into `~/.local`, and enables `librepods.service`.
- `BUILD_TESTING` now defaults off, so a user `cmake -B build -G Ninja` does not compile the Qt Test suite.

Install is now:

```bash
omarchy plugin add https://github.com/thisisgm/omarchy-pods --enable
~/.config/omarchy/plugins/io.github.thisisgm.omapods/setup
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated setup process that installs dependencies, builds and installs the daemon, and enables its user service.
  * Added guidance for manual daemon builds and configuring visibility while disconnected.

* **Documentation**
  * Updated installation and usage instructions.
  * Removed outdated manual build and bar-move steps.

* **Chores**
  * Added an option to control whether tests are built, disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->