### PR TITLE
fix: recover AirPods control link after transient disconnect

### DIFF
--- a/daemon/BluetoothMonitor.cpp
+++ b/daemon/BluetoothMonitor.cpp
@@ -112,6 +112,38 @@ bool BluetoothMonitor::checkAlreadyConnectedDevices()
     return deviceFound;
 }
 
+bool BluetoothMonitor::isDeviceConnected(const QString &macAddress)
+{
+    if (macAddress.isEmpty() || !m_dbus.isConnected()) {
+        return false;
+    }
+
+    QDBusInterface objectManager("org.bluez", "/", "org.freedesktop.DBus.ObjectManager", m_dbus);
+    const QDBusMessage reply = objectManager.call("GetManagedObjects");
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
+        LOG_WARN("Failed to query BlueZ connection state for " << macAddress
+                 << ": " << reply.errorMessage());
+        return false;
+    }
+
+    const QDBusArgument arg = reply.arguments().constFirst().value<QDBusArgument>();
+    ManagedObjectList managedObjects;
+    arg >> managedObjects;
+
+    for (auto it = managedObjects.constBegin(); it != managedObjects.constEnd(); ++it) {
+        const QVariantMap deviceProps = it.value().value("org.bluez.Device1");
+        if (deviceProps.isEmpty()) {
+            continue;
+        }
+        if (deviceProps.value("Address").toString().compare(macAddress, Qt::CaseInsensitive) != 0) {
+            continue;
+        }
+        return deviceProps.value("Connected").toBool();
+    }
+
+    return false;
+}
+
 void BluetoothMonitor::onPropertiesChanged(const QDBusMessage &message)
 {
     // Filter at the path level: only BlueZ Device1 objects, never the

--- a/daemon/BluetoothMonitor.cpp
+++ b/daemon/BluetoothMonitor.cpp
@@ -112,36 +112,40 @@ bool BluetoothMonitor::checkAlreadyConnectedDevices()
     return deviceFound;
 }
 
-bool BluetoothMonitor::isDeviceConnected(const QString &macAddress)
+void BluetoothMonitor::probeDeviceConnected(const QString &macAddress, quint64 requestId)
 {
     if (macAddress.isEmpty() || !m_dbus.isConnected()) {
-        return false;
+        emit deviceConnectionProbeFinished(macAddress, requestId, false);
+        return;
     }
 
     QDBusInterface objectManager("org.bluez", "/", "org.freedesktop.DBus.ObjectManager", m_dbus);
-    const QDBusMessage reply = objectManager.call("GetManagedObjects");
-    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
-        LOG_WARN("Failed to query BlueZ connection state for " << macAddress
-                 << ": " << reply.errorMessage());
-        return false;
-    }
+    auto *watcher = new QDBusPendingCallWatcher(objectManager.asyncCall("GetManagedObjects"), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, watcher, macAddress, requestId](QDBusPendingCallWatcher *) {
+                bool connected = false;
+                const QDBusMessage reply = watcher->reply();
+                if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
+                    LOG_WARN("Failed to query BlueZ connection state for " << macAddress
+                             << ": " << reply.errorMessage());
+                } else {
+                    const QDBusArgument arg = reply.arguments().constFirst().value<QDBusArgument>();
+                    ManagedObjectList managedObjects;
+                    arg >> managedObjects;
 
-    const QDBusArgument arg = reply.arguments().constFirst().value<QDBusArgument>();
-    ManagedObjectList managedObjects;
-    arg >> managedObjects;
+                    for (auto it = managedObjects.constBegin(); it != managedObjects.constEnd(); ++it) {
+                        const QVariantMap deviceProps = it.value().value("org.bluez.Device1");
+                        if (deviceProps.value("Address").toString().compare(
+                                macAddress, Qt::CaseInsensitive) == 0) {
+                            connected = deviceProps.value("Connected").toBool();
+                            break;
+                        }
+                    }
+                }
 
-    for (auto it = managedObjects.constBegin(); it != managedObjects.constEnd(); ++it) {
-        const QVariantMap deviceProps = it.value().value("org.bluez.Device1");
-        if (deviceProps.isEmpty()) {
-            continue;
-        }
-        if (deviceProps.value("Address").toString().compare(macAddress, Qt::CaseInsensitive) != 0) {
-            continue;
-        }
-        return deviceProps.value("Connected").toBool();
-    }
-
-    return false;
+                emit deviceConnectionProbeFinished(macAddress, requestId, connected);
+                watcher->deleteLater();
+            });
 }
 
 void BluetoothMonitor::onPropertiesChanged(const QDBusMessage &message)

--- a/daemon/BluetoothMonitor.h
+++ b/daemon/BluetoothMonitor.h
@@ -16,6 +16,7 @@ public:
     ~BluetoothMonitor() override;
 
     bool checkAlreadyConnectedDevices();
+    bool isDeviceConnected(const QString &macAddress);
 
 signals:
     void deviceConnected(const QString &macAddress, const QString &deviceName);

--- a/daemon/BluetoothMonitor.h
+++ b/daemon/BluetoothMonitor.h
@@ -16,11 +16,13 @@ public:
     ~BluetoothMonitor() override;
 
     bool checkAlreadyConnectedDevices();
-    bool isDeviceConnected(const QString &macAddress);
+    void probeDeviceConnected(const QString &macAddress, quint64 requestId);
 
 signals:
     void deviceConnected(const QString &macAddress, const QString &deviceName);
     void deviceDisconnected(const QString &macAddress, const QString &deviceName);
+    void deviceConnectionProbeFinished(const QString &macAddress, quint64 requestId,
+                                       bool connected);
 
 private slots:
     // Receive the raw QDBusMessage so we can read message.path() reliably

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -45,6 +45,7 @@ qt_add_executable(librepods
     media/playerstatuswatcher.cpp
     media/playerstatuswatcher.h
     systemsleepmonitor.hpp
+    controlreconnect.hpp
 )
 
 set_source_files_properties(Theme.qml PROPERTIES

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -1,9 +1,18 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 
 namespace ControlReconnect
 {
+enum class State
+{
+    Idle,
+    Waiting,
+    ProbingBlueZ,
+    ConnectingSocket
+};
+
 inline int delayMs(int attempt, int jitterMs)
 {
     const int boundedAttempt = std::clamp(attempt, 1, 10);
@@ -15,4 +24,71 @@ inline bool hasAttemptRemaining(int completedAttempts, int maximumAttempts)
 {
     return completedAttempts < std::max(0, maximumAttempts);
 }
+
+class Session
+{
+public:
+    void begin(bool bleScanWasActive)
+    {
+        m_state = State::Waiting;
+        m_completedAttempts = 0;
+        m_restoreBleScan = bleScanWasActive;
+        ++m_generation;
+    }
+
+    bool isActive() const { return m_state != State::Idle; }
+    State state() const { return m_state; }
+    int completedAttempts() const { return m_completedAttempts; }
+
+    std::uint64_t beginProbe()
+    {
+        m_state = State::ProbingBlueZ;
+        return ++m_generation;
+    }
+
+    bool acceptsProbe(std::uint64_t generation) const
+    {
+        return m_state == State::ProbingBlueZ && generation == m_generation;
+    }
+
+    void beginConnection()
+    {
+        m_state = State::ConnectingSocket;
+        ++m_generation;
+    }
+
+    bool prepareRetry(int maximumAttempts)
+    {
+        if (!isActive() || !hasAttemptRemaining(m_completedAttempts, maximumAttempts)) {
+            return false;
+        }
+        ++m_completedAttempts;
+        m_state = State::Waiting;
+        ++m_generation;
+        return true;
+    }
+
+    bool complete()
+    {
+        const bool restoreBleScan = m_restoreBleScan;
+        reset();
+        return restoreBleScan;
+    }
+
+    void cancel() { reset(); }
+
+private:
+    void reset()
+    {
+        m_state = State::Idle;
+        m_completedAttempts = 0;
+        m_restoreBleScan = false;
+        ++m_generation;
+    }
+
+    State m_state = State::Idle;
+    int m_completedAttempts = 0;
+    bool m_restoreBleScan = false;
+    std::uint64_t m_generation = 0;
+};
 }

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -13,11 +13,20 @@ enum class State
     ConnectingSocket
 };
 
+// Doubling from one second, capped so a long-lived session cannot overflow the shift.
+inline constexpr int baseDelayMs = 1000;
+inline constexpr int maxDoublings = 10;
+inline constexpr int maxJitterMs = 499;
+inline constexpr int jitterRangeMs = maxJitterMs + 1;
+
+// Short enough that a real profile rebuild is still in progress when the first probe runs.
+inline constexpr int firstDelayMs = 750;
+
 inline int delayMs(int attempt, int jitterMs)
 {
-    const int boundedAttempt = std::clamp(attempt, 1, 10);
-    const int boundedJitter = std::clamp(jitterMs, 0, 499);
-    return 1000 * (1 << (boundedAttempt - 1)) + boundedJitter;
+    const int boundedAttempt = std::clamp(attempt, 1, maxDoublings);
+    const int boundedJitter = std::clamp(jitterMs, 0, maxJitterMs);
+    return baseDelayMs * (1 << (boundedAttempt - 1)) + boundedJitter;
 }
 
 inline bool hasAttemptRemaining(int completedAttempts, int maximumAttempts)

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <algorithm>
+
+namespace ControlReconnect
+{
+inline int delayMs(int attempt, int jitterMs)
+{
+    const int boundedAttempt = std::clamp(attempt, 1, 10);
+    const int boundedJitter = std::clamp(jitterMs, 0, 499);
+    return 1000 * (1 << (boundedAttempt - 1)) + boundedJitter;
+}
+
+inline bool hasAttemptRemaining(int completedAttempts, int maximumAttempts)
+{
+    return completedAttempts < std::max(0, maximumAttempts);
+}
+}

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -115,11 +115,7 @@ public:
         connect(monitor, &BluetoothMonitor::deviceConnectionProbeFinished,
                 this, &AirPodsTrayApp::controlConnectionProbeFinished);
 
-        // The proprietary AAP control socket can disappear while BlueZ keeps
-        // the A2DP transport connected. Device1::Connected therefore cannot
-        // be relied on to emit another rising edge. Keep a small, independent
-        // recovery timer for that control link and leave the audio profile
-        // untouched while it retries.
+        // The control socket can drop while BlueZ keeps A2DP up, so Device1::Connected never rises again.
         m_controlReconnectTimer = new QTimer(this);
         m_controlReconnectTimer->setSingleShot(true);
         connect(m_controlReconnectTimer, &QTimer::timeout,
@@ -803,9 +799,7 @@ private slots:
                 LOG_DEBUG("Control recovery connection is already in progress");
                 return;
             }
-            if (m_controlReconnectTimer) {
-                m_controlReconnectTimer->stop();
-            }
+            m_controlReconnectTimer->stop();
             m_controlRecovery.beginConnection();
         }
         connectToDevice(device, recovering);
@@ -838,11 +832,7 @@ private slots:
             socket = nullptr;
         }
 
-        // BlueZ may briefly lower Device1::Connected while rebuilding one
-        // profile even though A2DP immediately survives or reconnects. Delay
-        // the full-disconnect path and first try to restore only the AAP
-        // control socket. This avoids discovery and profile churn in an
-        // otherwise healthy audio session.
+        // BlueZ lowers Connected while rebuilding a profile, so try the control socket before tearing down.
         scheduleControlReconnect(address.toString(), m_lastAirPodsName,
                                  QStringLiteral("BlueZ disconnect event"));
     }
@@ -853,9 +843,7 @@ private slots:
             return;
         }
         m_disconnectFinalized = true;
-        if (m_controlReconnectTimer) {
-            m_controlReconnectTimer->stop();
-        }
+        m_controlReconnectTimer->stop();
         m_controlRecovery.cancel();
         m_retryCount = 0;
 
@@ -882,8 +870,6 @@ private slots:
         if (trayManager) {
             trayManager->resetTrayIcon();
         }
-
-        LOG_INFO("AirPods control recovery exhausted for " << address);
     }
 
     void rememberAirPodsDevice(const QString &address, const QString &name)
@@ -907,16 +893,14 @@ private slots:
 
         const bool bleScanWasActive = m_bleManager->isScanning();
 
-        // Discovery competes with A2DP on constrained controllers. Keep it
-        // stopped during recovery, then restore the policy that was active
-        // before the control link disappeared.
+        // Recovery re-opens an L2CAP socket, so discovery pauses for that window and is restored after.
         m_bleManager->stopScan();
 
         if (!m_controlRecovery.isActive()) {
             m_controlRecovery.begin(bleScanWasActive);
             m_disconnectFinalized = false;
             LOG_INFO("Scheduling AirPods control reconnect after " << reason);
-            m_controlReconnectTimer->start(750);
+            m_controlReconnectTimer->start(ControlReconnect::firstDelayMs);
         } else if (m_controlRecovery.state() == ControlReconnect::State::ConnectingSocket) {
             scheduleControlRecoveryRetry(reason);
         }
@@ -962,13 +946,13 @@ private slots:
             return;
         }
 
-        scheduleControlRecoveryRetry(QStringLiteral("BlueZ is not connected"));
+        scheduleControlRecoveryRetry(QStringLiteral("BlueZ did not report the device as connected"));
     }
 
     void scheduleControlRecoveryRetry(const QString &reason)
     {
         if (m_controlRecovery.prepareRetry(m_retryAttempts)) {
-            const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(500));
+            const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(ControlReconnect::jitterRangeMs));
             const int attempt = m_controlRecovery.completedAttempts();
             const int delay = ControlReconnect::delayMs(attempt, jitter);
             LOG_INFO("Retrying AirPods control recovery after " << reason << " ("
@@ -978,6 +962,7 @@ private slots:
         }
 
         ++m_reconnectFailuresTotal;
+        LOG_INFO("AirPods control recovery exhausted for " << m_lastAirPodsAddress);
         finalizeDeviceDisconnected(m_lastAirPodsAddress);
     }
 
@@ -987,9 +972,7 @@ private slots:
             return;
         }
 
-        if (m_controlReconnectTimer) {
-            m_controlReconnectTimer->stop();
-        }
+        m_controlReconnectTimer->stop();
         const bool restoreBleScan = m_controlRecovery.complete();
         m_disconnectFinalized = false;
         if (restoreBleScan) {
@@ -1148,7 +1131,7 @@ private slots:
                 // Fixed-delay 1500ms hammered BlueZ if multiple peers were
                 // also retrying after a controller reset — exponential
                 // spacing + jitter avoids the thundering-herd reconnect.
-                const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(500));
+                const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(ControlReconnect::jitterRangeMs));
                 const int delay = ControlReconnect::delayMs(m_retryCount, jitter);
                 LOG_INFO("Retrying connection (attempt " << m_retryCount << "/" << m_retryAttempts
                          << ", delay=" << delay << "ms, total=" << m_reconnectAttemptsTotal << ")");

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -46,6 +46,7 @@
 #include "ble/bleutils.h"
 #include "QRCodeImageProvider.hpp"
 #include "systemsleepmonitor.hpp"
+#include "controlreconnect.hpp"
 
 using namespace AirpodsTrayApp::Enums;
 
@@ -111,6 +112,16 @@ public:
         monitor = new BluetoothMonitor(this);
         connect(monitor, &BluetoothMonitor::deviceConnected, this, &AirPodsTrayApp::bluezDeviceConnected);
         connect(monitor, &BluetoothMonitor::deviceDisconnected, this, &AirPodsTrayApp::bluezDeviceDisconnected);
+
+        // The proprietary AAP control socket can disappear while BlueZ keeps
+        // the A2DP transport connected. Device1::Connected therefore cannot
+        // be relied on to emit another rising edge. Keep a small, independent
+        // recovery timer for that control link and leave the audio profile
+        // untouched while it retries.
+        m_controlReconnectTimer = new QTimer(this);
+        m_controlReconnectTimer->setSingleShot(true);
+        connect(m_controlReconnectTimer, &QTimer::timeout,
+                this, &AirPodsTrayApp::attemptControlReconnect);
 
         connect(m_bleManager, &BleManager::deviceFound, this, &AirPodsTrayApp::bleDeviceFound);
         connect(m_deviceInfo->getBattery(), &Battery::primaryChanged, this, &AirPodsTrayApp::primaryChanged);
@@ -780,6 +791,13 @@ private slots:
 
     void bluezDeviceConnected(const QString &address, const QString &name)
     {
+        rememberAirPodsDevice(address, name);
+        m_disconnectFinalized = false;
+        m_controlReconnectProbeCount = 0;
+        if (m_controlReconnectTimer) {
+            m_controlReconnectTimer->stop();
+        }
+
         QBluetoothDeviceInfo device(QBluetoothAddress(address), name, 0);
         connectToDevice(device);
 
@@ -810,6 +828,23 @@ private slots:
             socket->deleteLater();
             socket = nullptr;
         }
+
+        // BlueZ may briefly lower Device1::Connected while rebuilding one
+        // profile even though A2DP immediately survives or reconnects. Delay
+        // the full-disconnect path and first try to restore only the AAP
+        // control socket. This avoids discovery and profile churn in an
+        // otherwise healthy audio session.
+        scheduleControlReconnect(address.toString(), m_lastAirPodsName,
+                                 QStringLiteral("BlueZ disconnect event"));
+    }
+
+    void finalizeDeviceDisconnected(const QString &address)
+    {
+        if (m_disconnectFinalized) {
+            return;
+        }
+        m_disconnectFinalized = true;
+
         if (phoneSocket && phoneSocket->isOpen())
         {
             phoneSocket->write(AirPodsPackets::Connection::AIRPODS_DISCONNECTED);
@@ -833,6 +868,78 @@ private slots:
         if (trayManager) {
             trayManager->resetTrayIcon();
         }
+
+        LOG_INFO("AirPods control recovery exhausted for " << address);
+    }
+
+    void rememberAirPodsDevice(const QString &address, const QString &name)
+    {
+        if (!address.isEmpty()) {
+            m_lastAirPodsAddress = address;
+        }
+        if (!name.isEmpty()) {
+            m_lastAirPodsName = name;
+        }
+    }
+
+    void scheduleControlReconnect(const QString &address, const QString &name,
+                                  const QString &reason)
+    {
+        rememberAirPodsDevice(address, name);
+        if (m_lastAirPodsAddress.isEmpty() || m_isSuspending) {
+            finalizeDeviceDisconnected(address);
+            return;
+        }
+
+        // Discovery competes with A2DP on constrained controllers. Keep it
+        // stopped during the short grace period; start it only after recovery
+        // is genuinely exhausted and the device is fully disconnected.
+        m_bleManager->stopScan();
+
+        if (m_controlReconnectTimer && !m_controlReconnectTimer->isActive()) {
+            m_controlReconnectProbeCount = 0;
+            m_disconnectFinalized = false;
+            LOG_INFO("Scheduling AirPods control reconnect after " << reason);
+            m_controlReconnectTimer->start(750);
+        }
+    }
+
+    void attemptControlReconnect()
+    {
+        if (areAirpodsConnected()) {
+            m_controlReconnectProbeCount = 0;
+            return;
+        }
+
+        const QString address = m_lastAirPodsAddress;
+        if (address.isEmpty()) {
+            finalizeDeviceDisconnected(address);
+            return;
+        }
+
+        if (monitor && monitor->isDeviceConnected(address)) {
+            ++m_reconnectAttemptsTotal;
+            LOG_INFO("Reconnecting AirPods control link (attempt total="
+                     << m_reconnectAttemptsTotal << ")");
+            QBluetoothDeviceInfo device(QBluetoothAddress(address), m_lastAirPodsName, 0);
+            connectToDevice(device);
+            return;
+        }
+
+        if (ControlReconnect::hasAttemptRemaining(m_controlReconnectProbeCount,
+                                                  m_retryAttempts)) {
+            ++m_controlReconnectProbeCount;
+            const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(500));
+            const int delay = ControlReconnect::delayMs(m_controlReconnectProbeCount, jitter);
+            LOG_INFO("AirPods not yet connected in BlueZ; checking again ("
+                     << m_controlReconnectProbeCount << "/" << m_retryAttempts
+                     << ", delay=" << delay << "ms)");
+            m_controlReconnectTimer->start(delay);
+            return;
+        }
+
+        ++m_reconnectFailuresTotal;
+        finalizeDeviceDisconnected(address);
     }
 
     void bluezDeviceDisconnected(const QString &address, const QString &name)
@@ -920,6 +1027,7 @@ private slots:
         }
 
         LOG_INFO("Connecting to device: " << device.name());
+        rememberAirPodsDevice(device.address().toString(), device.name());
 
         // Clean up any existing socket (defensive: disconnect first so any
         // queued slot can't reach a half-dead object).
@@ -936,7 +1044,13 @@ private slots:
         // Connection handler
         auto handleConnection = [this, localSocket]()
         {
+            localSocket->setProperty("openpodsControlConnected", true);
             m_retryCount = 0;
+            m_controlReconnectProbeCount = 0;
+            m_disconnectFinalized = false;
+            if (m_controlReconnectTimer) {
+                m_controlReconnectTimer->stop();
+            }
             stopBleScanWhileConnected();
             connect(localSocket, &QBluetoothSocket::readyRead, this, [this, localSocket]()
                     {
@@ -953,6 +1067,14 @@ private slots:
         {
             LOG_ERROR("Socket error: " << error << ", " << localSocket->errorString());
 
+            // Once a control link has been established, a later socket error
+            // is a link-loss event, not another initial-connect failure.
+            if (localSocket->property("openpodsControlConnected").toBool()) {
+                handleControlSocketLoss(device, localSocket,
+                                        QStringLiteral("socket error"));
+                return;
+            }
+
             if (m_retryCount < m_retryAttempts)
             {
                 m_retryCount++;
@@ -962,9 +1084,8 @@ private slots:
                 // Fixed-delay 1500ms hammered BlueZ if multiple peers were
                 // also retrying after a controller reset — exponential
                 // spacing + jitter avoids the thundering-herd reconnect.
-                const int base = 1000 * (1 << (m_retryCount - 1));
                 const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(500));
-                const int delay = base + jitter;
+                const int delay = ControlReconnect::delayMs(m_retryCount, jitter);
                 LOG_INFO("Retrying connection (attempt " << m_retryCount << "/" << m_retryAttempts
                          << ", delay=" << delay << "ms, total=" << m_reconnectAttemptsTotal << ")");
                 QTimer::singleShot(delay, this, [this, device]()
@@ -982,10 +1103,37 @@ private slots:
         connect(localSocket, &QBluetoothSocket::connected, this, handleConnection);
         connect(localSocket, QOverload<QBluetoothSocket::SocketError>::of(&QBluetoothSocket::errorOccurred),
                 this, handleError);
+        connect(localSocket, &QBluetoothSocket::disconnected, this,
+                [this, device, localSocket]() {
+                    if (!localSocket->property("openpodsControlConnected").toBool()) {
+                        return;
+                    }
+                    handleControlSocketLoss(device, localSocket,
+                                            QStringLiteral("socket disconnected"));
+                });
 
         localSocket->connectToService(device.address(), QBluetoothUuid("74ec2172-0bad-4d01-8f77-997b2be0722a"));
         m_deviceInfo->setBluetoothAddress(device.address().toString());
         notifyAndroidDevice();
+    }
+
+    void handleControlSocketLoss(const QBluetoothDeviceInfo &device,
+                                 QBluetoothSocket *lostSocket,
+                                 const QString &reason)
+    {
+        // errorOccurred and disconnected commonly arrive for the same loss;
+        // only the first callback for the currently-owned socket may recover.
+        if (!lostSocket || socket != lostSocket) {
+            return;
+        }
+
+        LOG_WARN("AirPods control link lost: " << reason);
+        lostSocket->disconnect(this);
+        lostSocket->close();
+        lostSocket->deleteLater();
+        socket = nullptr;
+
+        scheduleControlReconnect(device.address().toString(), device.name(), reason);
     }
 
     void parseData(const QByteArray &data)
@@ -1367,11 +1515,16 @@ private:
     // Null in a headless run; every use needs a guard.
     TrayIconManager *trayManager = nullptr;
     BluetoothMonitor *monitor;
+    QTimer *m_controlReconnectTimer = nullptr;
     QSettings *m_settings;
     AutoStartManager *m_autoStartManager;
     int m_retryAttempts = 3;
     int m_retryCount = 0;
+    int m_controlReconnectProbeCount = 0;
     bool m_isSuspending = false;
+    bool m_disconnectFinalized = false;
+    QString m_lastAirPodsAddress;
+    QString m_lastAirPodsName;
 
     // Reliability counters — process-lifetime totals, logged on quit.
     // Exposed to QML readers via the public getters below.

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -112,6 +112,8 @@ public:
         monitor = new BluetoothMonitor(this);
         connect(monitor, &BluetoothMonitor::deviceConnected, this, &AirPodsTrayApp::bluezDeviceConnected);
         connect(monitor, &BluetoothMonitor::deviceDisconnected, this, &AirPodsTrayApp::bluezDeviceDisconnected);
+        connect(monitor, &BluetoothMonitor::deviceConnectionProbeFinished,
+                this, &AirPodsTrayApp::controlConnectionProbeFinished);
 
         // The proprietary AAP control socket can disappear while BlueZ keeps
         // the A2DP transport connected. Device1::Connected therefore cannot
@@ -793,17 +795,24 @@ private slots:
     {
         rememberAirPodsDevice(address, name);
         m_disconnectFinalized = false;
-        m_controlReconnectProbeCount = 0;
-        if (m_controlReconnectTimer) {
-            m_controlReconnectTimer->stop();
-        }
 
         QBluetoothDeviceInfo device(QBluetoothAddress(address), name, 0);
-        connectToDevice(device);
+        const bool recovering = m_controlRecovery.isActive();
+        if (recovering) {
+            if (m_controlRecovery.state() == ControlReconnect::State::ConnectingSocket && socket) {
+                LOG_DEBUG("Control recovery connection is already in progress");
+                return;
+            }
+            if (m_controlReconnectTimer) {
+                m_controlReconnectTimer->stop();
+            }
+            m_controlRecovery.beginConnection();
+        }
+        connectToDevice(device, recovering);
 
         // After system reboot, AirPods might be connected but A2DP profile not active
         // Attempt to activate A2DP profile after a delay to ensure connection is established
-        QTimer::singleShot(2000, this, [this, address]()
+        if (!recovering) QTimer::singleShot(2000, this, [this, address]()
         {
             if (!address.isEmpty())
             {
@@ -844,6 +853,11 @@ private slots:
             return;
         }
         m_disconnectFinalized = true;
+        if (m_controlReconnectTimer) {
+            m_controlReconnectTimer->stop();
+        }
+        m_controlRecovery.cancel();
+        m_retryCount = 0;
 
         if (phoneSocket && phoneSocket->isOpen())
         {
@@ -891,23 +905,31 @@ private slots:
             return;
         }
 
+        const bool bleScanWasActive = m_bleManager->isScanning();
+
         // Discovery competes with A2DP on constrained controllers. Keep it
-        // stopped during the short grace period; start it only after recovery
-        // is genuinely exhausted and the device is fully disconnected.
+        // stopped during recovery, then restore the policy that was active
+        // before the control link disappeared.
         m_bleManager->stopScan();
 
-        if (m_controlReconnectTimer && !m_controlReconnectTimer->isActive()) {
-            m_controlReconnectProbeCount = 0;
+        if (!m_controlRecovery.isActive()) {
+            m_controlRecovery.begin(bleScanWasActive);
             m_disconnectFinalized = false;
             LOG_INFO("Scheduling AirPods control reconnect after " << reason);
             m_controlReconnectTimer->start(750);
+        } else if (m_controlRecovery.state() == ControlReconnect::State::ConnectingSocket) {
+            scheduleControlRecoveryRetry(reason);
         }
     }
 
     void attemptControlReconnect()
     {
+        if (m_controlRecovery.state() != ControlReconnect::State::Waiting) {
+            return;
+        }
+
         if (areAirpodsConnected()) {
-            m_controlReconnectProbeCount = 0;
+            finishControlRecovery();
             return;
         }
 
@@ -917,29 +939,65 @@ private slots:
             return;
         }
 
-        if (monitor && monitor->isDeviceConnected(address)) {
-            ++m_reconnectAttemptsTotal;
-            LOG_INFO("Reconnecting AirPods control link (attempt total="
-                     << m_reconnectAttemptsTotal << ")");
-            QBluetoothDeviceInfo device(QBluetoothAddress(address), m_lastAirPodsName, 0);
-            connectToDevice(device);
+        const quint64 requestId = m_controlRecovery.beginProbe();
+        monitor->probeDeviceConnected(address, requestId);
+    }
+
+    void controlConnectionProbeFinished(const QString &address, quint64 requestId,
+                                        bool connected)
+    {
+        if (address.compare(m_lastAirPodsAddress, Qt::CaseInsensitive) != 0
+            || !m_controlRecovery.acceptsProbe(requestId)) {
+            LOG_DEBUG("Ignoring stale AirPods connection probe");
             return;
         }
 
-        if (ControlReconnect::hasAttemptRemaining(m_controlReconnectProbeCount,
-                                                  m_retryAttempts)) {
-            ++m_controlReconnectProbeCount;
+        if (connected) {
+            ++m_reconnectAttemptsTotal;
+            LOG_INFO("Reconnecting AirPods control link (attempt total="
+                     << m_reconnectAttemptsTotal << ")");
+            m_controlRecovery.beginConnection();
+            QBluetoothDeviceInfo device(QBluetoothAddress(address), m_lastAirPodsName, 0);
+            connectToDevice(device, true);
+            return;
+        }
+
+        scheduleControlRecoveryRetry(QStringLiteral("BlueZ is not connected"));
+    }
+
+    void scheduleControlRecoveryRetry(const QString &reason)
+    {
+        if (m_controlRecovery.prepareRetry(m_retryAttempts)) {
             const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(500));
-            const int delay = ControlReconnect::delayMs(m_controlReconnectProbeCount, jitter);
-            LOG_INFO("AirPods not yet connected in BlueZ; checking again ("
-                     << m_controlReconnectProbeCount << "/" << m_retryAttempts
-                     << ", delay=" << delay << "ms)");
+            const int attempt = m_controlRecovery.completedAttempts();
+            const int delay = ControlReconnect::delayMs(attempt, jitter);
+            LOG_INFO("Retrying AirPods control recovery after " << reason << " ("
+                     << attempt << "/" << m_retryAttempts << ", delay=" << delay << "ms)");
             m_controlReconnectTimer->start(delay);
             return;
         }
 
         ++m_reconnectFailuresTotal;
-        finalizeDeviceDisconnected(address);
+        finalizeDeviceDisconnected(m_lastAirPodsAddress);
+    }
+
+    void finishControlRecovery()
+    {
+        if (!m_controlRecovery.isActive()) {
+            return;
+        }
+
+        if (m_controlReconnectTimer) {
+            m_controlReconnectTimer->stop();
+        }
+        const bool restoreBleScan = m_controlRecovery.complete();
+        m_disconnectFinalized = false;
+        if (restoreBleScan) {
+            m_bleManager->startScan();
+        } else {
+            m_bleManager->stopScan();
+        }
+        LOG_INFO("AirPods control link recovered");
     }
 
     void bluezDeviceDisconnected(const QString &address, const QString &name)
@@ -1018,7 +1076,7 @@ private slots:
                                                             : "In case";
     }
 
-    void connectToDevice(const QBluetoothDeviceInfo &device)
+    void connectToDevice(const QBluetoothDeviceInfo &device, bool controlRecovery = false)
     {
         if (socket && socket->isOpen() && socket->peerAddress() == device.address())
         {
@@ -1039,6 +1097,7 @@ private slots:
         }
 
         QBluetoothSocket *localSocket = new QBluetoothSocket(QBluetoothServiceInfo::L2capProtocol, this);
+        localSocket->setProperty("openpodsControlRecovery", controlRecovery);
         socket = localSocket;
 
         // Connection handler
@@ -1046,10 +1105,9 @@ private slots:
         {
             localSocket->setProperty("openpodsControlConnected", true);
             m_retryCount = 0;
-            m_controlReconnectProbeCount = 0;
             m_disconnectFinalized = false;
-            if (m_controlReconnectTimer) {
-                m_controlReconnectTimer->stop();
+            if (localSocket->property("openpodsControlRecovery").toBool()) {
+                finishControlRecovery();
             }
             stopBleScanWhileConnected();
             connect(localSocket, &QBluetoothSocket::readyRead, this, [this, localSocket]()
@@ -1072,6 +1130,12 @@ private slots:
             if (localSocket->property("openpodsControlConnected").toBool()) {
                 handleControlSocketLoss(device, localSocket,
                                         QStringLiteral("socket error"));
+                return;
+            }
+
+            if (localSocket->property("openpodsControlRecovery").toBool()) {
+                handleControlConnectFailure(device, localSocket,
+                                            QStringLiteral("socket error before connection"));
                 return;
             }
 
@@ -1106,6 +1170,11 @@ private slots:
         connect(localSocket, &QBluetoothSocket::disconnected, this,
                 [this, device, localSocket]() {
                     if (!localSocket->property("openpodsControlConnected").toBool()) {
+                        if (localSocket->property("openpodsControlRecovery").toBool()) {
+                            handleControlConnectFailure(
+                                device, localSocket,
+                                QStringLiteral("socket disconnected before connection"));
+                        }
                         return;
                     }
                     handleControlSocketLoss(device, localSocket,
@@ -1115,6 +1184,23 @@ private slots:
         localSocket->connectToService(device.address(), QBluetoothUuid("74ec2172-0bad-4d01-8f77-997b2be0722a"));
         m_deviceInfo->setBluetoothAddress(device.address().toString());
         notifyAndroidDevice();
+    }
+
+    void handleControlConnectFailure(const QBluetoothDeviceInfo &device,
+                                     QBluetoothSocket *failedSocket,
+                                     const QString &reason)
+    {
+        if (!failedSocket || socket != failedSocket || !m_controlRecovery.isActive()) {
+            return;
+        }
+
+        LOG_WARN("AirPods control reconnect failed: " << reason);
+        failedSocket->disconnect(this);
+        failedSocket->close();
+        failedSocket->deleteLater();
+        socket = nullptr;
+        rememberAirPodsDevice(device.address().toString(), device.name());
+        scheduleControlRecoveryRetry(reason);
     }
 
     void handleControlSocketLoss(const QBluetoothDeviceInfo &device,
@@ -1520,7 +1606,7 @@ private:
     AutoStartManager *m_autoStartManager;
     int m_retryAttempts = 3;
     int m_retryCount = 0;
-    int m_controlReconnectProbeCount = 0;
+    ControlReconnect::Session m_controlRecovery;
     bool m_isSuspending = false;
     bool m_disconnectFinalized = false;
     QString m_lastAirPodsAddress;

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -893,7 +893,7 @@ private slots:
 
         const bool bleScanWasActive = m_bleManager->isScanning();
 
-        // Recovery re-opens an L2CAP socket, so discovery pauses for that window and is restored after.
+        // A live scan delays the L2CAP connect this recovery depends on, so pause it and restore after.
         m_bleManager->stopScan();
 
         if (!m_controlRecovery.isActive()) {

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -62,6 +62,11 @@ openpods_add_test(tst_lowbatterywatcher
     ../lowbatterywatcher.hpp
 )
 
+openpods_add_test(tst_controlreconnect
+    tst_controlreconnect.cpp
+    ../controlreconnect.hpp
+)
+
 openpods_add_test(tst_snaptogrid
     tst_snaptogrid.cpp
     ../snaptogrid.hpp

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -63,7 +63,7 @@ private slots:
         QVERIFY(!session.complete());
     }
 
-    void aFinalizedSessionCannotBeRetried()
+    void aCancelledSessionCannotBeRetried()
     {
         ControlReconnect::Session session;
         session.begin(true);
@@ -72,11 +72,23 @@ private slots:
         session.cancel();
         QCOMPARE(session.state(), ControlReconnect::State::Idle);
         QVERIFY(!session.isActive());
-
-        // The timer that was already queued when finalize ran must not restart the session.
         QVERIFY(!session.acceptsProbe(probe));
         QVERIFY(!session.prepareRetry(3));
         QVERIFY(!session.complete());
+    }
+
+    void aProbeFromASupersededSessionIsRejected()
+    {
+        ControlReconnect::Session session;
+        session.begin(true);
+        const auto firstProbe = session.beginProbe();
+
+        // A second disconnect restarts the session while the first probe is still in flight.
+        session.begin(true);
+        const auto secondProbe = session.beginProbe();
+
+        QVERIFY(!session.acceptsProbe(firstProbe));
+        QVERIFY(session.acceptsProbe(secondProbe));
     }
 };
 

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -52,7 +52,7 @@ private slots:
         QVERIFY(!session.acceptsProbe(secondProbe));
     }
 
-    void exhaustsSharedRetryBudget()
+    void stopsRetryingAtTheAttemptLimit()
     {
         ControlReconnect::Session session;
         session.begin(false);
@@ -60,6 +60,22 @@ private slots:
         QVERIFY(session.prepareRetry(2));
         QVERIFY(!session.prepareRetry(2));
         QCOMPARE(session.completedAttempts(), 2);
+        QVERIFY(!session.complete());
+    }
+
+    void aFinalizedSessionCannotBeRetried()
+    {
+        ControlReconnect::Session session;
+        session.begin(true);
+        const auto probe = session.beginProbe();
+
+        session.cancel();
+        QCOMPARE(session.state(), ControlReconnect::State::Idle);
+        QVERIFY(!session.isActive());
+
+        // The timer that was already queued when finalize ran must not restart the session.
+        QVERIFY(!session.acceptsProbe(probe));
+        QVERIFY(!session.prepareRetry(3));
         QVERIFY(!session.complete());
     }
 };

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -83,10 +83,14 @@ private slots:
         session.begin(true);
         const auto firstProbe = session.beginProbe();
 
-        // A second disconnect restarts the session while the first probe is still in flight.
-        session.begin(true);
-        const auto secondProbe = session.beginProbe();
+        // Production only restarts a session after finalize cancels it, so drive that order.
+        session.cancel();
+        QVERIFY(!session.acceptsProbe(firstProbe));
 
+        session.begin(true);
+        QVERIFY(!session.acceptsProbe(firstProbe));
+
+        const auto secondProbe = session.beginProbe();
         QVERIFY(!session.acceptsProbe(firstProbe));
         QVERIFY(session.acceptsProbe(secondProbe));
     }

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -27,6 +27,41 @@ private slots:
         QVERIFY(!ControlReconnect::hasAttemptRemaining(3, 3));
         QVERIFY(!ControlReconnect::hasAttemptRemaining(0, 0));
     }
+
+    void tracksRecoveryLifecycle()
+    {
+        ControlReconnect::Session session;
+        session.begin(true);
+        QCOMPARE(session.state(), ControlReconnect::State::Waiting);
+
+        const auto firstProbe = session.beginProbe();
+        QVERIFY(session.acceptsProbe(firstProbe));
+        session.beginConnection();
+        QVERIFY(!session.acceptsProbe(firstProbe));
+        QCOMPARE(session.state(), ControlReconnect::State::ConnectingSocket);
+
+        QVERIFY(session.prepareRetry(3));
+        QCOMPARE(session.completedAttempts(), 1);
+        QCOMPARE(session.state(), ControlReconnect::State::Waiting);
+
+        const auto secondProbe = session.beginProbe();
+        QVERIFY(session.acceptsProbe(secondProbe));
+        QVERIFY(!session.acceptsProbe(firstProbe));
+        QVERIFY(session.complete());
+        QCOMPARE(session.state(), ControlReconnect::State::Idle);
+        QVERIFY(!session.acceptsProbe(secondProbe));
+    }
+
+    void exhaustsSharedRetryBudget()
+    {
+        ControlReconnect::Session session;
+        session.begin(false);
+        QVERIFY(session.prepareRetry(2));
+        QVERIFY(session.prepareRetry(2));
+        QVERIFY(!session.prepareRetry(2));
+        QCOMPARE(session.completedAttempts(), 2);
+        QVERIFY(!session.complete());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestControlReconnect)

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -1,0 +1,33 @@
+#include <QtTest>
+
+#include "../controlreconnect.hpp"
+
+class TestControlReconnect : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void usesExponentialBackoff()
+    {
+        QCOMPARE(ControlReconnect::delayMs(1, 0), 1000);
+        QCOMPARE(ControlReconnect::delayMs(2, 250), 2250);
+        QCOMPARE(ControlReconnect::delayMs(3, 499), 4499);
+    }
+
+    void boundsInputs()
+    {
+        QCOMPARE(ControlReconnect::delayMs(0, -1), 1000);
+        QCOMPARE(ControlReconnect::delayMs(20, 999), 512499);
+    }
+
+    void stopsAtConfiguredLimit()
+    {
+        QVERIFY(ControlReconnect::hasAttemptRemaining(0, 3));
+        QVERIFY(ControlReconnect::hasAttemptRemaining(2, 3));
+        QVERIFY(!ControlReconnect::hasAttemptRemaining(3, 3));
+        QVERIFY(!ControlReconnect::hasAttemptRemaining(0, 0));
+    }
+};
+
+QTEST_GUILESS_MAIN(TestControlReconnect)
+#include "tst_controlreconnect.moc"

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -91,6 +91,7 @@ private slots:
         QVERIFY(!session.acceptsProbe(firstProbe));
 
         const auto secondProbe = session.beginProbe();
+        QVERIFY(firstProbe != secondProbe);
         QVERIFY(!session.acceptsProbe(firstProbe));
         QVERIFY(session.acceptsProbe(secondProbe));
     }


### PR DESCRIPTION
## What changed

- Detect post-connection control-socket disconnects and errors.
- Retain the known device identity and retry the proprietary control link independently.
- Query live BlueZ state before reconnecting.
- Use bounded retry/backoff with jitter.
- Keep BLE discovery stopped while recovering the control link.
- Finalize a full disconnect only after bounded recovery fails.
- Add unit coverage for the retry/backoff policy.

## Why

A2DP can remain connected while the AirPods control socket disappears. The previous behavior treated that as a full disconnect and waited for a new BlueZ `Connected` rising edge, which may never arrive while audio remains connected. Battery and control features could then stay stale until the daemon was restarted.

## Relationship to existing work

Fixes #7.

This is complementary to #5, which handles the separate PipeWire/BlueZ card-publication race during A2DP profile activation. This PR handles control-link loss after a successful connection and does not duplicate that A2DP activation change.

## Validation

- RelWithDebInfo CMake/Ninja build completed successfully.
- `ctest --test-dir build --output-on-failure`: 16/16 tests passed.
- `git diff --check`: passed.
- Live hardware testing observed a control-socket loss; the daemon entered its recovery path while the audio connection remained available, and the control link subsequently re-established.

The PR is intentionally opened as a draft for maintainer review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Bluetooth connection-state detection for paired devices.
  - Added automatic recovery for AirPods control connections after temporary link loss.

- **Bug Fixes**
  - Improved reconnection reliability with controlled retries and increasing delays.
  - Prevented unnecessary Bluetooth discovery restarts and A2DP interruptions during recovery.
  - Improved handling of connection failures, unexpected disconnects, and temporary Bluetooth service interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->