### PR TITLE
Decode AirPods Pro 3 from the BLE model id

### DIFF
--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -21,7 +21,9 @@ AirpodsTrayApp::Enums::AirPodsModel getModelName(quint16 modelId)
         {0x1F20, AirPodsModel::AirPodsMaxUSBC},
         {0x0E20, AirPodsModel::AirPodsPro},
         {0x1420, AirPodsModel::AirPodsPro2Lightning},
-        {0x2420, AirPodsModel::AirPodsPro2USBC}
+        {0x2420, AirPodsModel::AirPodsPro2USBC},
+        // Apple ships the Pro 3 as product 0x2027, and this frame carries it big-endian.
+        {0x2720, AirPodsModel::AirPodsPro3}
     };
 
     return modelMap.value(modelId, AirPodsModel::Unknown);

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -22,7 +22,7 @@ AirpodsTrayApp::Enums::AirPodsModel getModelName(quint16 modelId)
         {0x0E20, AirPodsModel::AirPodsPro},
         {0x1420, AirPodsModel::AirPodsPro2Lightning},
         {0x2420, AirPodsModel::AirPodsPro2USBC},
-        // Apple ships the Pro 3 as product 0x2027, and this frame carries it big-endian.
+        // Apple product 0x2027 arrives byte-swapped, so data[3] is 0x27 and this key is 0x2720.
         {0x2720, AirPodsModel::AirPodsPro3}
     };
 

--- a/daemon/tests/tst_blemanager.cpp
+++ b/daemon/tests/tst_blemanager.cpp
@@ -96,6 +96,8 @@ void TestBleManager::realAirPodsFrameIsParsed()
     BleInfo parsed;
 
     QCOMPARE(parseFrame(QByteArray::fromHex(airPodsFrameHex), &parsed), 1);
+    // The capture is an AirPods Pro 3, model id 0x2720 big-endian over data[3..4].
+    QCOMPARE(int(parsed.modelName), int(AirpodsTrayApp::Enums::AirPodsModel::AirPodsPro3));
     // Decoded from the capture: 0x8f is a case nibble of 15 meaning absent, 0x04 is idle.
     QCOMPARE(parsed.caseBattery, -1);
     QCOMPARE(parsed.connectionState, BleInfo::ConnectionState::IDLE);

--- a/daemon/tests/tst_blemanager.cpp
+++ b/daemon/tests/tst_blemanager.cpp
@@ -96,7 +96,7 @@ void TestBleManager::realAirPodsFrameIsParsed()
     BleInfo parsed;
 
     QCOMPARE(parseFrame(QByteArray::fromHex(airPodsFrameHex), &parsed), 1);
-    // The capture is an AirPods Pro 3, model id 0x2720 big-endian over data[3..4].
+    // Captured from the operator own AirPods Pro 3: data[3..4] is 27 20, so the key is 0x2720.
     QCOMPARE(int(parsed.modelName), int(AirpodsTrayApp::Enums::AirPodsModel::AirPodsPro3));
     // Decoded from the capture: 0x8f is a case nibble of 15 meaning absent, 0x04 is idle.
     QCOMPARE(parsed.caseBattery, -1);

--- a/daemon/tests/tst_blemanager.cpp
+++ b/daemon/tests/tst_blemanager.cpp
@@ -96,7 +96,7 @@ void TestBleManager::realAirPodsFrameIsParsed()
     BleInfo parsed;
 
     QCOMPARE(parseFrame(QByteArray::fromHex(airPodsFrameHex), &parsed), 1);
-    // Captured from the operator own AirPods Pro 3: data[3..4] is 27 20, so the key is 0x2720.
+    // Captured from the operator's own AirPods Pro 3: data[3..4] is 27 20, so the key is 0x2720.
     QCOMPARE(int(parsed.modelName), int(AirpodsTrayApp::Enums::AirPodsModel::AirPodsPro3));
     // Decoded from the capture: 0x8f is a case nibble of 15 meaning absent, 0x04 is idle.
     QCOMPARE(parsed.caseBattery, -1);


### PR DESCRIPTION
The proximity parser composes the model id as `(data[3] << 8) | data[4]`, which is `0x2720` for the AirPods Pro 3, and `modelMap` stopped at `0x2420`. Every BLE-sourced surface therefore showed `Unknown` while the same buds identified correctly over AAP, which is why the bar and panel could disagree with the tray.

The frame the merged BLE test already uses was captured live from these buds, so the assertion is one line in the existing `realAirPodsFrameIsParsed` rather than a new file.

Negative control on the box: with the map row removed the assertion fails with `Actual 0` against `Expected 11`. With it, `ctest` is 17 of 17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for AirPods Pro 3 and AirPods Pro 2 USB-C devices.

* **Bug Fixes**
  * Improved Bluetooth advertisement classification for AirPods Pro 3 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->