### PR TITLE
Point the README at the contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ not JSON, and a schema newer than this panel reads.
 deno run --allow-read tests/model.test.js
 ```
 
+## Contributing
+
+Bug reports and pull requests are welcome. [CONTRIBUTING.md](CONTRIBUTING.md)
+covers the build, what review will ask you to prove, and the house style;
+[AGENTS.md](AGENTS.md) adds the traps coding agents hit in this tree.
+
 ## Credits
 
 The hard part is not this panel. It is


### PR DESCRIPTION
A contributing guide nobody can find from the README is half shipped. One section above Credits, linking CONTRIBUTING.md and AGENTS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Contributing section to the README.
  * Linked to contribution, build, review, style, and coding-agent guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->