### PR TITLE
Detect the UART Apple controller when pausing the BLE scan

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -46,6 +46,7 @@ qt_add_executable(librepods
     media/playerstatuswatcher.h
     systemsleepmonitor.hpp
     controlreconnect.hpp
+    applecontroller.hpp
 )
 
 set_source_files_properties(Theme.qml PROPERTIES

--- a/daemon/applecontroller.hpp
+++ b/daemon/applecontroller.hpp
@@ -5,11 +5,8 @@
 
 namespace AppleController
 {
-// Apple ships this controller on USB, carrying vendor id 05AC, and on UART,
-// where the ACPI id has no vendor field and reads APPLE-UART-BLTH instead.
-// Samples: usb:v05ACp8290d0112... and acpi:BCM2E7C:APPLE-UART-BLTH:
-// Both markers are matched whole, so an unrelated ACPI id that merely starts
-// with APPLE does not pause the scan on hardware that never asked for it.
+// Sample input: usb:v05ACp8290d0112dcE0dsc01dp01icE0isc01ip01in00 or acpi:BCM2E7C:APPLE-UART-BLTH:
+// The UART part carries no vendor field, so its ACPI id is the only marker Apple leaves there.
 inline bool modaliasIsApple(const QString &modalias)
 {
     return modalias.contains(QLatin1String("v05AC"), Qt::CaseInsensitive)

--- a/daemon/applecontroller.hpp
+++ b/daemon/applecontroller.hpp
@@ -6,7 +6,7 @@
 namespace AppleController
 {
 // Sample input: usb:v05ACp8290d0112dcE0dsc01dp01icE0isc01ip01in00 or acpi:BCM2E7C:APPLE-UART-BLTH:
-// The UART part carries no vendor field, so its ACPI id is the only marker Apple leaves there.
+// Apple's USB vendor id is 05AC, and the UART part carries no vendor field at all, so its ACPI id is the only marker there.
 inline bool modaliasIsApple(const QString &modalias)
 {
     return modalias.contains(QLatin1String("v05AC"), Qt::CaseInsensitive)

--- a/daemon/applecontroller.hpp
+++ b/daemon/applecontroller.hpp
@@ -8,9 +8,11 @@ namespace AppleController
 // Apple ships this controller on USB, carrying vendor id 05AC, and on UART,
 // where the ACPI id has no vendor field and reads APPLE-UART-BLTH instead.
 // Samples: usb:v05ACp8290d0112... and acpi:BCM2E7C:APPLE-UART-BLTH:
+// Both markers are matched whole, so an unrelated ACPI id that merely starts
+// with APPLE does not pause the scan on hardware that never asked for it.
 inline bool modaliasIsApple(const QString &modalias)
 {
     return modalias.contains(QLatin1String("v05AC"), Qt::CaseInsensitive)
-        || modalias.contains(QLatin1String("APPLE"), Qt::CaseInsensitive);
+        || modalias.contains(QLatin1String("APPLE-UART-BLTH"), Qt::CaseInsensitive);
 }
 }

--- a/daemon/applecontroller.hpp
+++ b/daemon/applecontroller.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QLatin1String>
+#include <QString>
+
+namespace AppleController
+{
+// Apple ships this controller on USB, carrying vendor id 05AC, and on UART,
+// where the ACPI id has no vendor field and reads APPLE-UART-BLTH instead.
+// Samples: usb:v05ACp8290d0112... and acpi:BCM2E7C:APPLE-UART-BLTH:
+inline bool modaliasIsApple(const QString &modalias)
+{
+    return modalias.contains(QLatin1String("v05AC"), Qt::CaseInsensitive)
+        || modalias.contains(QLatin1String("APPLE"), Qt::CaseInsensitive);
+}
+}

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -47,6 +47,7 @@
 #include "ble/bleutils.h"
 #include "QRCodeImageProvider.hpp"
 #include "systemsleepmonitor.hpp"
+#include "applecontroller.hpp"
 #include "controlreconnect.hpp"
 
 using namespace AirpodsTrayApp::Enums;
@@ -679,8 +680,8 @@ public slots:
     int loadRetryAttempts() const { return m_settings->value("bluetooth/retryAttempts", 3).toInt(); }
     void saveRetryAttempts(int attempts) { m_settings->setValue("bluetooth/retryAttempts", attempts); }
 
-    // Sample input: usb:v8087p0A2Bd0010dcE0dsc01dp01icE0isc01ip01in00
-    // Only Apple's own controller (vendor 05AC) drops A2DP packets under continuous BLE discovery.
+    // Only Apple's own controller drops A2DP packets under continuous BLE
+    // discovery, and it spells its modalias differently on USB and on UART.
     static bool bluetoothControllerIsApple()
     {
         static const bool affected = []() {
@@ -691,7 +692,7 @@ public slots:
                 QFile modalias(sys.filePath(adapter) + QStringLiteral("/device/modalias"));
                 if (!modalias.open(QIODevice::ReadOnly | QIODevice::Text))
                     continue;
-                if (QString::fromLatin1(modalias.readAll()).contains(QStringLiteral("v05AC"), Qt::CaseInsensitive))
+                if (AppleController::modaliasIsApple(QString::fromLatin1(modalias.readAll())))
                     return true;
             }
             return false;

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -680,8 +680,7 @@ public slots:
     int loadRetryAttempts() const { return m_settings->value("bluetooth/retryAttempts", 3).toInt(); }
     void saveRetryAttempts(int attempts) { m_settings->setValue("bluetooth/retryAttempts", attempts); }
 
-    // Only Apple's own controller drops A2DP packets under continuous BLE
-    // discovery, and it spells its modalias differently on USB and on UART.
+    // Only Apple's own controller drops A2DP packets under continuous BLE discovery.
     static bool bluetoothControllerIsApple()
     {
         static const bool affected = []() {

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -67,6 +67,11 @@ openpods_add_test(tst_controlreconnect
     ../controlreconnect.hpp
 )
 
+openpods_add_test(tst_applecontroller
+    tst_applecontroller.cpp
+    ../applecontroller.hpp
+)
+
 openpods_add_test(tst_snaptogrid
     tst_snaptogrid.cpp
     ../snaptogrid.hpp

--- a/daemon/tests/tst_applecontroller.cpp
+++ b/daemon/tests/tst_applecontroller.cpp
@@ -1,0 +1,42 @@
+#include <QtTest>
+
+#include "../applecontroller.hpp"
+
+class TestAppleController : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void detectsTheUsbAppleController()
+    {
+        QVERIFY(AppleController::modaliasIsApple(
+            QStringLiteral("usb:v05ACp8290d0112dcE0dsc01dp01icE0isc01ip01in00")));
+    }
+
+    void detectsTheUartAppleController()
+    {
+        // Read off a MacBookPro14,1 running hci_uart_bcm, where a 05AC test never fires.
+        QVERIFY(AppleController::modaliasIsApple(
+            QStringLiteral("acpi:BCM2E7C:APPLE-UART-BLTH:")));
+    }
+
+    void leavesOtherVendorsAlone()
+    {
+        // Intel, the common non-Apple case, plus a non-Apple ACPI id.
+        QVERIFY(!AppleController::modaliasIsApple(
+            QStringLiteral("usb:v8087p0A2Bd0010dcE0dsc01dp01icE0isc01ip01in00")));
+        QVERIFY(!AppleController::modaliasIsApple(
+            QStringLiteral("acpi:BCM2E39:")));
+        QVERIFY(!AppleController::modaliasIsApple(QString()));
+    }
+
+    void matchesRegardlessOfCase()
+    {
+        // sysfs spelling is not guaranteed and the USB test was already case-insensitive.
+        QVERIFY(AppleController::modaliasIsApple(QStringLiteral("usb:v05acp8290")));
+        QVERIFY(AppleController::modaliasIsApple(QStringLiteral("acpi:BCM2E7C:apple-uart-blth:")));
+    }
+};
+
+QTEST_GUILESS_MAIN(TestAppleController)
+#include "tst_applecontroller.moc"

--- a/daemon/tests/tst_applecontroller.cpp
+++ b/daemon/tests/tst_applecontroller.cpp
@@ -9,15 +9,16 @@ class TestAppleController : public QObject
 private slots:
     void detectsTheUsbAppleController()
     {
+        // sysfs newline-terminates modalias and the caller does not trim it, so the fixtures carry it.
         QVERIFY(AppleController::modaliasIsApple(
-            QStringLiteral("usb:v05ACp8290d0112dcE0dsc01dp01icE0isc01ip01in00")));
+            QStringLiteral("usb:v05ACp8290d0112dcE0dsc01dp01icE0isc01ip01in00\n")));
     }
 
     void detectsTheUartAppleController()
     {
         // Read off a MacBookPro14,1 running hci_uart_bcm, where a 05AC test never fires.
         QVERIFY(AppleController::modaliasIsApple(
-            QStringLiteral("acpi:BCM2E7C:APPLE-UART-BLTH:")));
+            QStringLiteral("acpi:BCM2E7C:APPLE-UART-BLTH:\n")));
     }
 
     void leavesOtherVendorsAlone()
@@ -30,12 +31,15 @@ private slots:
         // An ACPI id that only starts with APPLE is not the UART controller.
         QVERIFY(!AppleController::modaliasIsApple(
             QStringLiteral("acpi:BCM2E39:APPLE-OTHER:")));
+        // 05AC as somebody else's product id is not Apple's vendor field, which is what the v prefix guards.
+        QVERIFY(!AppleController::modaliasIsApple(
+            QStringLiteral("usb:v8087p05ACd0010dcE0dsc01dp01icE0isc01ip01in00")));
         QVERIFY(!AppleController::modaliasIsApple(QString()));
     }
 
     void matchesRegardlessOfCase()
     {
-        // sysfs spelling is not guaranteed and the USB test was already case-insensitive.
+        // The kernel's own spelling is not guaranteed, so neither marker may assume upper case.
         QVERIFY(AppleController::modaliasIsApple(QStringLiteral("usb:v05acp8290")));
         QVERIFY(AppleController::modaliasIsApple(QStringLiteral("acpi:BCM2E7C:apple-uart-blth:")));
     }

--- a/daemon/tests/tst_applecontroller.cpp
+++ b/daemon/tests/tst_applecontroller.cpp
@@ -27,6 +27,9 @@ private slots:
             QStringLiteral("usb:v8087p0A2Bd0010dcE0dsc01dp01icE0isc01ip01in00")));
         QVERIFY(!AppleController::modaliasIsApple(
             QStringLiteral("acpi:BCM2E39:")));
+        // An ACPI id that only starts with APPLE is not the UART controller.
+        QVERIFY(!AppleController::modaliasIsApple(
+            QStringLiteral("acpi:BCM2E39:APPLE-OTHER:")));
         QVERIFY(!AppleController::modaliasIsApple(QString()));
     }
 


### PR DESCRIPTION
## What

`bluetoothControllerIsApple()` reads the adapter modalias and looks for vendor
id `05AC`. Apple also ships this controller behind UART, where it enumerates
over ACPI with no vendor field at all, so on a MacBookPro14,1 the modalias is

```
acpi:BCM2E7C:APPLE-UART-BLTH:      (driver hci_uart_bcm)
```

and the test never matches. The BLE scan pause added in 4b2ff4f is therefore
skipped on exactly the Apple Broadcom silicon it was written for, and discovery
keeps running through A2DP playback.

## Why it matters

Audible stutter during playback, continuously, on an affected machine.
`stopBleScanWhileConnected()` returns at its first condition, so the
"Stopping BLE scan while AirPods control link is connected" line never appears
in the journal on these boxes.

## Reproduction

MacBookPro14,1, AirPods Pro 3, A2DP connected, music playing.

Before:

```
$ bluetoothctl show | grep -i discovering
        Discovering: yes            # stays yes for as long as the link is up
$ journalctl --user -u librepods.service | grep -c "Stopping BLE scan"
0
$ dmesg | grep -c "unknown advertising packet type"
1688                                # climbing continuously
```

After:

```
$ bluetoothctl show | grep -i discovering
        Discovering: no
$ journalctl --user -u librepods.service | grep "Stopping BLE scan"
... Stopping BLE scan while AirPods control link is connected
```

Advertising packet count held flat over 20 seconds, against a continuous climb
before the change.

## The change

The predicate moves to `applecontroller.hpp` so it can be tested, per the
CONTRIBUTING note that a test cannot reach `main.cpp`. The sysfs walk stays
where it was. `tst_applecontroller` covers both bus spellings, mixed case, and
the non-Apple vendors that must keep discovery running.

Checked red before the fix: `detectsTheUartAppleController` and
`matchesRegardlessOfCase` fail against the old predicate while the USB and
non-Apple cases still pass, so the test is not passing trivially.

Full suite: 18 passed, 18 total.

## Assumptions worth checking

- Any adapter modalias containing `APPLE` is Apple silicon. On this machine the
  string comes from the ACPI device id, not from a free-form field. If that is
  too broad for your taste, matching `APPLE-UART-BLTH` exactly would also fix
  this box, at the cost of missing other UART spellings.
- The tradeoff this enables is the documented one: case and lid battery stop
  updating live while connected, which is already what USB Apple users get.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple controller detection across USB and UART Bluetooth adapter formats.
  * Detection is now case-insensitive and avoids incorrectly identifying unrelated devices.
  * Improved control-link recovery when devices appear connected but are not responding, with more reliable retry handling.

* **Tests**
  * Added coverage for Apple, non-Apple, empty, USB, and UART device identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->