### PR TITLE
Keep retrying the control link while BlueZ still holds the device

### DIFF
--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -13,9 +13,9 @@ enum class State
     ConnectingSocket
 };
 
-// Doubling from one second, capped so a long-lived session cannot overflow the shift.
+// Doubling from one second, capped at 16s because a device BlueZ still reports connected is retried forever.
 inline constexpr int baseDelayMs = 1000;
-inline constexpr int maxDoublings = 10;
+inline constexpr int maxDoublings = 5;
 inline constexpr int maxJitterMs = 499;
 inline constexpr int jitterRangeMs = maxJitterMs + 1;
 
@@ -41,6 +41,7 @@ public:
     {
         m_state = State::Waiting;
         m_completedAttempts = 0;
+        m_absentProbes = 0;
         m_restoreBleScan = bleScanWasActive;
         ++m_generation;
     }
@@ -66,10 +67,17 @@ public:
         ++m_generation;
     }
 
-    bool prepareRetry(int maximumAttempts)
+    bool prepareRetry(int maximumAttempts, bool deviceStillConnected)
     {
-        if (!isActive() || !hasAttemptRemaining(m_completedAttempts, maximumAttempts)) {
+        if (!isActive()) {
             return false;
+        }
+        // A device BlueZ still reports connected accepts the socket eventually, so only its absence is counted out.
+        if (!deviceStillConnected) {
+            if (!hasAttemptRemaining(m_absentProbes, maximumAttempts)) {
+                return false;
+            }
+            ++m_absentProbes;
         }
         ++m_completedAttempts;
         m_state = State::Waiting;
@@ -91,12 +99,14 @@ private:
     {
         m_state = State::Idle;
         m_completedAttempts = 0;
+        m_absentProbes = 0;
         m_restoreBleScan = false;
         ++m_generation;
     }
 
     State m_state = State::Idle;
     int m_completedAttempts = 0;
+    int m_absentProbes = 0;
     bool m_restoreBleScan = false;
     std::uint64_t m_generation = 0;
 };

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -49,7 +49,6 @@ public:
 
     bool isActive() const { return m_state != State::Idle; }
     State state() const { return m_state; }
-    int completedAttempts() const { return m_absentProbes + m_connectedAttempts; }
     int absentProbes() const { return m_absentProbes; }
     int connectedAttempts() const { return m_connectedAttempts; }
 

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -13,7 +13,7 @@ enum class State
     ConnectingSocket
 };
 
-// Doubling from one second, capped at 16s because a device BlueZ still reports connected is retried forever.
+// Doubling from one second, capped at 16s so a long recovery polls rather than sleeps through the reconnect.
 inline constexpr int baseDelayMs = 1000;
 inline constexpr int maxDoublings = 5;
 inline constexpr int maxJitterMs = 499;
@@ -21,6 +21,9 @@ inline constexpr int jitterRangeMs = maxJitterMs + 1;
 
 // Short enough that a real profile rebuild is still in progress when the first probe runs.
 inline constexpr int firstDelayMs = 750;
+
+// Ten retries on the ladder above is roughly two minutes, longer than any profile rebuild measured here.
+inline constexpr int connectedAttemptLimit = 10;
 
 inline int delayMs(int attempt, int jitterMs)
 {
@@ -39,16 +42,16 @@ class Session
 public:
     void begin(bool bleScanWasActive)
     {
+        reset();
         m_state = State::Waiting;
-        m_completedAttempts = 0;
-        m_absentProbes = 0;
         m_restoreBleScan = bleScanWasActive;
-        ++m_generation;
     }
 
     bool isActive() const { return m_state != State::Idle; }
     State state() const { return m_state; }
-    int completedAttempts() const { return m_completedAttempts; }
+    int completedAttempts() const { return m_absentProbes + m_connectedAttempts; }
+    int absentProbes() const { return m_absentProbes; }
+    int connectedAttempts() const { return m_connectedAttempts; }
 
     std::uint64_t beginProbe()
     {
@@ -72,14 +75,18 @@ public:
         if (!isActive()) {
             return false;
         }
-        // A device BlueZ still reports connected accepts the socket eventually, so only its absence is counted out.
-        if (!deviceStillConnected) {
+        // A device BlueZ still reports connected is worth a longer ladder than one it says has gone.
+        if (deviceStillConnected) {
+            if (!hasAttemptRemaining(m_connectedAttempts, connectedAttemptLimit)) {
+                return false;
+            }
+            ++m_connectedAttempts;
+        } else {
             if (!hasAttemptRemaining(m_absentProbes, maximumAttempts)) {
                 return false;
             }
             ++m_absentProbes;
         }
-        ++m_completedAttempts;
         m_state = State::Waiting;
         ++m_generation;
         return true;
@@ -98,15 +105,15 @@ private:
     void reset()
     {
         m_state = State::Idle;
-        m_completedAttempts = 0;
         m_absentProbes = 0;
+        m_connectedAttempts = 0;
         m_restoreBleScan = false;
         ++m_generation;
     }
 
     State m_state = State::Idle;
-    int m_completedAttempts = 0;
     int m_absentProbes = 0;
+    int m_connectedAttempts = 0;
     bool m_restoreBleScan = false;
     std::uint64_t m_generation = 0;
 };

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -971,11 +971,12 @@ private slots:
     {
         if (m_controlRecovery.prepareRetry(m_retryAttempts, deviceStillConnected)) {
             const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(ControlReconnect::jitterRangeMs));
-            const int delay = ControlReconnect::delayMs(m_controlRecovery.completedAttempts(), jitter);
             const int spent = deviceStillConnected ? m_controlRecovery.connectedAttempts()
                                                    : m_controlRecovery.absentProbes();
             const int limit = deviceStillConnected ? ControlReconnect::connectedAttemptLimit
                                                    : m_retryAttempts;
+            // Each branch backs off on its own count, so the one number in the line explains the delay beside it.
+            const int delay = ControlReconnect::delayMs(spent, jitter);
             LOG_INFO("Retrying AirPods control recovery after " << reason << " ("
                      << spent << "/" << limit << ", delay=" << delay << "ms)");
             m_controlReconnectTimer->start(delay);

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -919,7 +919,7 @@ private slots:
             LOG_INFO("Scheduling AirPods control reconnect after " << reason);
             m_controlReconnectTimer->start(ControlReconnect::firstDelayMs);
         } else if (m_controlRecovery.state() == ControlReconnect::State::ConnectingSocket) {
-            scheduleControlRecoveryRetry(reason);
+            scheduleControlRecoveryRetry(reason, false);
         }
     }
 
@@ -963,23 +963,24 @@ private slots:
             return;
         }
 
-        scheduleControlRecoveryRetry(QStringLiteral("BlueZ did not report the device as connected"));
+        scheduleControlRecoveryRetry(QStringLiteral("BlueZ did not report the device as connected"), false);
     }
 
-    void scheduleControlRecoveryRetry(const QString &reason)
+    // deviceStillConnected exempts the retry from the attempt limit, because the endpoint is there and will accept.
+    void scheduleControlRecoveryRetry(const QString &reason, bool deviceStillConnected)
     {
-        if (m_controlRecovery.prepareRetry(m_retryAttempts)) {
+        if (m_controlRecovery.prepareRetry(m_retryAttempts, deviceStillConnected)) {
             const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(ControlReconnect::jitterRangeMs));
             const int attempt = m_controlRecovery.completedAttempts();
             const int delay = ControlReconnect::delayMs(attempt, jitter);
-            LOG_INFO("Retrying AirPods control recovery after " << reason << " ("
-                     << attempt << "/" << m_retryAttempts << ", delay=" << delay << "ms)");
+            LOG_INFO("Retrying AirPods control recovery after " << reason << " (attempt "
+                     << attempt << ", delay=" << delay << "ms)");
             m_controlReconnectTimer->start(delay);
             return;
         }
 
         ++m_reconnectFailuresTotal;
-        LOG_INFO("AirPods control recovery exhausted for " << m_lastAirPodsAddress);
+        LOG_INFO("AirPods stayed disconnected through control recovery, finalizing " << m_lastAirPodsAddress);
         finalizeDeviceDisconnected(m_lastAirPodsAddress);
     }
 
@@ -1162,6 +1163,9 @@ private slots:
                 LOG_ERROR("Failed to connect after " << m_retryAttempts
                           << " attempts (total failures=" << m_reconnectFailuresTotal << ")");
                 m_retryCount = 0;
+                // BlueZ never raises Connected again for a device it already holds, so hand over to the probe ladder.
+                scheduleControlReconnect(device.address().toString(), device.name(),
+                                         QStringLiteral("initial connect attempts exhausted"));
             }
         };
 
@@ -1201,7 +1205,7 @@ private slots:
         failedSocket->deleteLater();
         socket = nullptr;
         rememberAirPodsDevice(device.address().toString(), device.name());
-        scheduleControlRecoveryRetry(reason);
+        scheduleControlRecoveryRetry(reason, true);
     }
 
     void handleControlSocketLoss(const QBluetoothDeviceInfo &device,

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -966,21 +966,30 @@ private slots:
         scheduleControlRecoveryRetry(QStringLiteral("BlueZ did not report the device as connected"), false);
     }
 
-    // deviceStillConnected exempts the retry from the attempt limit, because the endpoint is there and will accept.
+    // deviceStillConnected picks the longer ladder, because BlueZ saying it has the device means the endpoint is there.
     void scheduleControlRecoveryRetry(const QString &reason, bool deviceStillConnected)
     {
         if (m_controlRecovery.prepareRetry(m_retryAttempts, deviceStillConnected)) {
             const int jitter = static_cast<int>(QRandomGenerator::global()->bounded(ControlReconnect::jitterRangeMs));
-            const int attempt = m_controlRecovery.completedAttempts();
-            const int delay = ControlReconnect::delayMs(attempt, jitter);
-            LOG_INFO("Retrying AirPods control recovery after " << reason << " (attempt "
-                     << attempt << ", delay=" << delay << "ms)");
+            const int delay = ControlReconnect::delayMs(m_controlRecovery.completedAttempts(), jitter);
+            const int spent = deviceStillConnected ? m_controlRecovery.connectedAttempts()
+                                                   : m_controlRecovery.absentProbes();
+            const int limit = deviceStillConnected ? ControlReconnect::connectedAttemptLimit
+                                                   : m_retryAttempts;
+            LOG_INFO("Retrying AirPods control recovery after " << reason << " ("
+                     << spent << "/" << limit << ", delay=" << delay << "ms)");
             m_controlReconnectTimer->start(delay);
             return;
         }
 
         ++m_reconnectFailuresTotal;
-        LOG_INFO("AirPods stayed disconnected through control recovery, finalizing " << m_lastAirPodsAddress);
+        if (deviceStillConnected) {
+            LOG_WARN("AirPods never accepted the control socket while BlueZ held "
+                     << m_lastAirPodsAddress << ", finalizing");
+        } else {
+            LOG_INFO("AirPods stayed disconnected through control recovery, finalizing "
+                     << m_lastAirPodsAddress);
+        }
         finalizeDeviceDisconnected(m_lastAirPodsAddress);
     }
 

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -17,7 +17,7 @@ private slots:
     void boundsInputs()
     {
         QCOMPARE(ControlReconnect::delayMs(0, -1), 1000);
-        QCOMPARE(ControlReconnect::delayMs(20, 999), 512499);
+        QCOMPARE(ControlReconnect::delayMs(20, 999), 16499);
     }
 
     void stopsAtConfiguredLimit()
@@ -40,7 +40,7 @@ private slots:
         QVERIFY(!session.acceptsProbe(firstProbe));
         QCOMPARE(session.state(), ControlReconnect::State::ConnectingSocket);
 
-        QVERIFY(session.prepareRetry(3));
+        QVERIFY(session.prepareRetry(3, false));
         QCOMPARE(session.completedAttempts(), 1);
         QCOMPARE(session.state(), ControlReconnect::State::Waiting);
 
@@ -56,11 +56,34 @@ private slots:
     {
         ControlReconnect::Session session;
         session.begin(false);
-        QVERIFY(session.prepareRetry(2));
-        QVERIFY(session.prepareRetry(2));
-        QVERIFY(!session.prepareRetry(2));
+        QVERIFY(session.prepareRetry(2, false));
+        QVERIFY(session.prepareRetry(2, false));
+        QVERIFY(!session.prepareRetry(2, false));
         QCOMPARE(session.completedAttempts(), 2);
         QVERIFY(!session.complete());
+    }
+
+    void keepsRetryingWhileBlueZReportsTheDeviceConnected()
+    {
+        ControlReconnect::Session session;
+        session.begin(false);
+
+        for (int i = 0; i < 20; ++i) {
+            QVERIFY(session.prepareRetry(3, true));
+        }
+        QCOMPARE(session.completedAttempts(), 20);
+    }
+
+    void countsOnlyTheRetriesTakenWhileBlueZReportsTheDeviceGone()
+    {
+        ControlReconnect::Session session;
+        session.begin(false);
+
+        QVERIFY(session.prepareRetry(2, false));
+        QVERIFY(session.prepareRetry(2, true));
+        QVERIFY(session.prepareRetry(2, false));
+        QVERIFY(!session.prepareRetry(2, false));
+        QCOMPARE(session.completedAttempts(), 3);
     }
 
     void aCancelledSessionCannotBeRetried()
@@ -73,7 +96,7 @@ private slots:
         QCOMPARE(session.state(), ControlReconnect::State::Idle);
         QVERIFY(!session.isActive());
         QVERIFY(!session.acceptsProbe(probe));
-        QVERIFY(!session.prepareRetry(3));
+        QVERIFY(!session.prepareRetry(3, false));
         QVERIFY(!session.complete());
     }
 

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -41,7 +41,7 @@ private slots:
         QCOMPARE(session.state(), ControlReconnect::State::ConnectingSocket);
 
         QVERIFY(session.prepareRetry(3, false));
-        QCOMPARE(session.completedAttempts(), 1);
+        QCOMPARE(session.absentProbes(), 1);
         QCOMPARE(session.state(), ControlReconnect::State::Waiting);
 
         const auto secondProbe = session.beginProbe();
@@ -59,7 +59,7 @@ private slots:
         QVERIFY(session.prepareRetry(2, false));
         QVERIFY(session.prepareRetry(2, false));
         QVERIFY(!session.prepareRetry(2, false));
-        QCOMPARE(session.completedAttempts(), 2);
+        QCOMPARE(session.absentProbes(), 2);
         QVERIFY(!session.complete());
     }
 
@@ -83,7 +83,7 @@ private slots:
             QVERIFY(session.prepareRetry(3, true));
         }
         QVERIFY(!session.prepareRetry(3, true));
-        QCOMPARE(session.completedAttempts(), ControlReconnect::connectedAttemptLimit);
+        QCOMPARE(session.connectedAttempts(), ControlReconnect::connectedAttemptLimit);
     }
 
     void aLimitOfZeroRefusesEveryAbsentRetry()
@@ -91,7 +91,7 @@ private slots:
         ControlReconnect::Session session;
         session.begin(false);
         QVERIFY(!session.prepareRetry(0, false));
-        QCOMPARE(session.completedAttempts(), 0);
+        QCOMPARE(session.absentProbes(), 0);
     }
 
     void aRestartedSessionGetsBothBudgetsBack()
@@ -104,7 +104,8 @@ private slots:
 
         // begin() on a session that is still active must not inherit the spent budget.
         session.begin(false);
-        QCOMPARE(session.completedAttempts(), 0);
+        QCOMPARE(session.absentProbes(), 0);
+        QCOMPARE(session.connectedAttempts(), 0);
         QVERIFY(session.prepareRetry(1, false));
         QVERIFY(session.prepareRetry(1, true));
     }
@@ -118,7 +119,8 @@ private slots:
         QVERIFY(session.prepareRetry(2, true));
         QVERIFY(session.prepareRetry(2, false));
         QVERIFY(!session.prepareRetry(2, false));
-        QCOMPARE(session.completedAttempts(), 3);
+        QCOMPARE(session.absentProbes(), 2);
+        QCOMPARE(session.connectedAttempts(), 1);
     }
 
     void aCancelledSessionCannotBeRetried()

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -63,15 +63,50 @@ private slots:
         QVERIFY(!session.complete());
     }
 
-    void keepsRetryingWhileBlueZReportsTheDeviceConnected()
+    void outlastsTheAbsentLimitWhileBlueZReportsTheDeviceConnected()
     {
         ControlReconnect::Session session;
         session.begin(false);
 
-        for (int i = 0; i < 20; ++i) {
+        for (int i = 0; i < ControlReconnect::connectedAttemptLimit; ++i) {
+            QVERIFY(session.prepareRetry(1, true));
+        }
+        QCOMPARE(session.connectedAttempts(), ControlReconnect::connectedAttemptLimit);
+    }
+
+    void stopsRetryingWhenTheDeviceNeverAcceptsTheSocket()
+    {
+        ControlReconnect::Session session;
+        session.begin(false);
+
+        for (int i = 0; i < ControlReconnect::connectedAttemptLimit; ++i) {
             QVERIFY(session.prepareRetry(3, true));
         }
-        QCOMPARE(session.completedAttempts(), 20);
+        QVERIFY(!session.prepareRetry(3, true));
+        QCOMPARE(session.completedAttempts(), ControlReconnect::connectedAttemptLimit);
+    }
+
+    void aLimitOfZeroRefusesEveryAbsentRetry()
+    {
+        ControlReconnect::Session session;
+        session.begin(false);
+        QVERIFY(!session.prepareRetry(0, false));
+        QCOMPARE(session.completedAttempts(), 0);
+    }
+
+    void aRestartedSessionGetsBothBudgetsBack()
+    {
+        ControlReconnect::Session session;
+        session.begin(false);
+        QVERIFY(session.prepareRetry(1, false));
+        QVERIFY(session.prepareRetry(1, true));
+        QVERIFY(!session.prepareRetry(1, false));
+
+        // begin() on a session that is still active must not inherit the spent budget.
+        session.begin(false);
+        QCOMPARE(session.completedAttempts(), 0);
+        QVERIFY(session.prepareRetry(1, false));
+        QVERIFY(session.prepareRetry(1, true));
     }
 
     void countsOnlyTheRetriesTakenWhileBlueZReportsTheDeviceGone()


### PR DESCRIPTION
Fixes #14.

## Reproduction

On minipc (Omarchy, Intel `usb:v8087p0A2B` adapter, AirPods Pro 3), driving
`org.bluez.Device1` `Disconnect` then `Connect` the way the stock Bluetooth panel
does, with a 12 second gap:

```
11:25:24.511  AirPods control recovery exhausted for "F4:33:B7:08:BB:C9"
11:25:28.398  Connecting to device: "GM's AirPods Pro"
11:25:28.410  Cannot connect to profile/service.
11:25:28.410  Socket error: HostNotFoundError, "Cannot connect to remote profile"
```

That cycle recovered on the fourth connect attempt. Shortening the ladder with
`bluetooth/retryAttempts=1` turned the same cycle into a permanent hang, which is
the negative control:

```
=== bluez ===  b true            # BlueZ still has the device, A2DP playing
=== daemon === "connected":false # still false 75 seconds later
```

Both ladders had run out, and BlueZ never raises `Connected` again for a device it
already holds, so nothing was scheduled and nothing ever would be.

## The fix

Only the retries taken while BlueZ says the device is absent count against
`bluetooth/retryAttempts`; a device BlueZ still holds gets its own longer ladder,
`connectedAttemptLimit`, and the initial-connect ladder hands over to the probe
ladder instead of giving up silently. The give-up line now says which of the two
happened, so an ordinary disconnect no longer reads as a failure.

## What I ran

Same repro, same `retryAttempts=1` state that hung:

```
11:32:39.757  Failed to connect after 1 attempts (total failures= 2 )
11:32:39.757  Scheduling AirPods control reconnect after "initial connect attempts exhausted"
11:32:40.559  AirPods control link recovered
=== daemon === "connected":true
```

Then restored the default and re-ran: normal three-attempt recovery, link back at
11:36:17. Suite 17 of 17, `tst_controlreconnect` 14 of 14. Checked red first:
`stopsRetryingWhenTheDeviceNeverAcceptsTheSocket` fails against an unbounded
branch, `aRestartedSessionGetsBothBudgetsBack` fails when `begin()` stops
delegating to `reset()`, and the two round-one cases fail against the old
predicate. `prepareRetry(0, true)` returning true 100000 times is what proved the
first shape of this fix was itself unbounded.

## Assumptions worth checking

- That BlueZ emits no further `Connected` transition for a device it already
  reports connected. Everything here rests on it, and it is what the permanent
  hang above demonstrates.
- The 80 second case in the issue is still unexplained. This bounds the wait at
  roughly two minutes rather than at nothing, so that case would now self-heal,
  but I did not reproduce it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AirPods control recovery when devices remain connected or temporarily disappear.
  * Reconnection attempts now use separate handling for connected and absent devices, improving recovery reliability.
  * Retry delays are capped to prevent excessively long waits.
  * Recovery now reports distinct outcomes when retry limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->