### PR TITLE
fix: re-arm A2DP activation after control link recovery

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -998,6 +998,18 @@ private slots:
             m_bleManager->stopScan();
         }
         LOG_INFO("AirPods control link recovered");
+
+        // onDeviceDisconnected() cancels any in-flight A2DP activation as soon as the
+        // control link blips, even though that blip is often just BlueZ rebuilding the
+        // profile right after connect (see its comment). If that cancellation raced the
+        // retry loop before it found the PipeWire bluez5 card, the card is left on the
+        // "off" profile with nothing left to retry it. Now that the link is confirmed
+        // back up, re-arm activation so the AirPods don't silently stay muted.
+        if (!m_lastAirPodsAddress.isEmpty()) {
+            QString formattedAddress = m_lastAirPodsAddress;
+            formattedAddress.replace(":", "_");
+            mediaController->activateA2dpProfileWithRetry(formattedAddress);
+        }
     }
 
     void bluezDeviceDisconnected(const QString &address, const QString &name)

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -999,12 +999,7 @@ private slots:
         }
         LOG_INFO("AirPods control link recovered");
 
-        // onDeviceDisconnected() cancels any in-flight A2DP activation as soon as the
-        // control link blips, even though that blip is often just BlueZ rebuilding the
-        // profile right after connect (see its comment). If that cancellation raced the
-        // retry loop before it found the PipeWire bluez5 card, the card is left on the
-        // "off" profile with nothing left to retry it. Now that the link is confirmed
-        // back up, re-arm activation so the AirPods don't silently stay muted.
+        // onDeviceDisconnected cancelled any in-flight activation, and a recovering connect skips the usual retry.
         if (!m_lastAirPodsAddress.isEmpty()) {
             QString formattedAddress = m_lastAirPodsAddress;
             formattedAddress.replace(":", "_");

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -308,11 +308,6 @@ bool MediaController::activateA2dpProfile() {
 
   // Re-applying the profile WirePlumber already set tears down the live sink under a playing stream.
   const QString activeProfile = m_pulseAudio->getActiveCardProfile(m_deviceOutputName);
-  // A call in progress holds the card on HSP/HFP, and switching it to A2DP would kill the microphone.
-  if (activeProfile.startsWith(QLatin1String("headset-head-unit"))) {
-    LOG_INFO("Headset profile active, leaving it in place: " << activeProfile);
-    return true;
-  }
   if (activeProfile == preferredProfile) {
     LOG_INFO("A2DP profile already active: " << activeProfile);
   } else {

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -308,6 +308,11 @@ bool MediaController::activateA2dpProfile() {
 
   // Re-applying the profile WirePlumber already set tears down the live sink under a playing stream.
   const QString activeProfile = m_pulseAudio->getActiveCardProfile(m_deviceOutputName);
+  // A call in progress holds the card on HSP/HFP, and switching it to A2DP would kill the microphone.
+  if (activeProfile.startsWith(QLatin1String("headset-head-unit"))) {
+    LOG_INFO("Headset profile active, leaving it in place: " << activeProfile);
+    return true;
+  }
   if (activeProfile == preferredProfile) {
     LOG_INFO("A2DP profile already active: " << activeProfile);
   } else {


### PR DESCRIPTION
Fixes #18

## Reproduction

Captured on real hardware: the control link blipped during the first few seconds after connect while `activateA2dpProfileWithRetry()` was still looking for the PipeWire `bluez5` card. `onDeviceDisconnected()` cancelled that retry chain, correctly for a real disconnect, but the link then recovered (`AirPods control link recovered`) and nothing re-armed activation. The card stayed on profile `off`, no sink, no output, confirmed with `pactl list cards short` / `pactl list sinks short`, while `bluetoothctl info` showed the device fully connected. `pactl set-card-profile <card> a2dp-sink` recovered it by hand every time, which rules out anything on the PipeWire/WirePlumber side.

## Fix

Re-arm `activateA2dpProfileWithRetry()` in `finishControlRecovery()` once the control link is confirmed back up, reusing the existing retry chain instead of adding a new one.

## What I ran to check it

- `cmake -B build -G Ninja && cmake --build build && ctest --test-dir build`: 17/17 tests pass.
- Installed the built daemon and restarted it on real hardware. On the next control-link blip during connect, the log shows `A2DP profile activation attempted for newly connected device` firing again right after `AirPods control link recovered`, and the AirPods sink appears in `pactl list sinks short` with no manual `pactl set-card-profile` call.
- Could not force the control-link blip itself on demand, it is a BlueZ/hardware timing race, so the fix was verified by waiting for it to recur naturally across several connect cycles rather than a synthetic repro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored media audio functionality after recovering an AirPods control connection.
  * Automatically reactivates the A2DP profile using the remembered Bluetooth device address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->