### PR TITLE
fix: retry control link recovery after it gives up

### DIFF
--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -25,11 +25,17 @@ inline constexpr int firstDelayMs = 750;
 // Ten retries on the ladder above is roughly two minutes, longer than any profile rebuild measured here.
 inline constexpr int connectedAttemptLimit = 10;
 
-// Fallback poll once even the connected-attempt ladder above is exhausted and nothing else
-// is left to notify us: BlueZ can settle into Device1::Connected without ever emitting
-// another PropertiesChanged transition, so a session that gave up would otherwise never be
-// retried. Slow enough to stay a safety net rather than a second retry loop.
+// BlueZ can settle into Device1::Connected without emitting another transition, so an exhausted session needs a poll to notice.
 inline constexpr int watchdogIntervalMs = 30000;
+
+// The watchdog is only for a control link that died while BlueZ kept the device; every other state must stay silent.
+inline bool shouldRetryFromWatchdog(bool controlSocketConnected, bool recoveryActive,
+                                    bool suspending, bool haveAddress,
+                                    bool bluezReportedConnected)
+{
+    return !controlSocketConnected && !recoveryActive && !suspending
+           && haveAddress && bluezReportedConnected;
+}
 
 inline int delayMs(int attempt, int jitterMs)
 {

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -25,6 +25,12 @@ inline constexpr int firstDelayMs = 750;
 // Ten retries on the ladder above is roughly two minutes, longer than any profile rebuild measured here.
 inline constexpr int connectedAttemptLimit = 10;
 
+// Fallback poll once even the connected-attempt ladder above is exhausted and nothing else
+// is left to notify us: BlueZ can settle into Device1::Connected without ever emitting
+// another PropertiesChanged transition, so a session that gave up would otherwise never be
+// retried. Slow enough to stay a safety net rather than a second retry loop.
+inline constexpr int watchdogIntervalMs = 30000;
+
 inline int delayMs(int attempt, int jitterMs)
 {
     const int boundedAttempt = std::clamp(attempt, 1, maxDoublings);

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -124,6 +124,15 @@ public:
         connect(m_controlReconnectTimer, &QTimer::timeout,
                 this, &AirPodsTrayApp::attemptControlReconnect);
 
+        // Its bounded retries (m_retryAttempts) can still exhaust with BlueZ sitting on
+        // Connected the whole time (no transition ever arrives to retrigger recovery) -
+        // this periodic check is the fallback for that case. See checkControlLinkWatchdog().
+        m_controlWatchdogTimer = new QTimer(this);
+        m_controlWatchdogTimer->setInterval(ControlReconnect::watchdogIntervalMs);
+        connect(m_controlWatchdogTimer, &QTimer::timeout,
+                this, &AirPodsTrayApp::checkControlLinkWatchdog);
+        m_controlWatchdogTimer->start();
+
         connect(m_bleManager, &BleManager::deviceFound, this, &AirPodsTrayApp::bleDeviceFound);
         connect(m_deviceInfo->getBattery(), &Battery::primaryChanged, this, &AirPodsTrayApp::primaryChanged);
         connect(m_systemSleepMonitor, &SystemSleepMonitor::systemGoingToSleep, this, &AirPodsTrayApp::onSystemGoingToSleep);
@@ -923,6 +932,28 @@ private slots:
         }
     }
 
+    // Runs every ControlReconnect::watchdogIntervalMs. scheduleControlReconnect() only
+    // fires from a BlueZ PropertiesChanged transition or a control-socket callback, so once
+    // its bounded retry budget (scheduleControlRecoveryRetry -> finalizeDeviceDisconnected)
+    // is exhausted, nothing retries again unless one of those events happens to fire - even
+    // though the AirPods can still be sitting connected the whole time. This is the fallback
+    // that notices and tries again, on a slow enough cadence to stay a safety net rather than
+    // a second retry loop racing the bounded one.
+    void checkControlLinkWatchdog()
+    {
+        if (areAirpodsConnected() || m_controlRecovery.isActive() || m_isSuspending) {
+            return;
+        }
+        if (m_lastAirPodsAddress.isEmpty()) {
+            return;
+        }
+
+        LOG_INFO("Control link watchdog: rechecking BlueZ connection state for "
+                 << m_lastAirPodsAddress);
+        scheduleControlReconnect(m_lastAirPodsAddress, m_lastAirPodsName,
+                                 QStringLiteral("watchdog recheck"));
+    }
+
     void attemptControlReconnect()
     {
         if (m_controlRecovery.state() != ControlReconnect::State::Waiting) {
@@ -1618,6 +1649,8 @@ private:
     TrayIconManager *trayManager = nullptr;
     BluetoothMonitor *monitor;
     QTimer *m_controlReconnectTimer = nullptr;
+    // Safety net behind m_controlReconnectTimer's bounded retries; see checkControlLinkWatchdog().
+    QTimer *m_controlWatchdogTimer = nullptr;
     QSettings *m_settings;
     AutoStartManager *m_autoStartManager;
     int m_retryAttempts = 3;

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -939,7 +939,7 @@ private slots:
             return;
         }
 
-        LOG_INFO("Control link watchdog: BlueZ still reports the device connected, retrying "
+        LOG_INFO("Control link watchdog: last BlueZ probe said connected, retrying "
                  << m_lastAirPodsAddress);
         scheduleControlReconnect(m_lastAirPodsAddress, m_lastAirPodsName,
                                  QStringLiteral("watchdog recheck"));

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -124,9 +124,7 @@ public:
         connect(m_controlReconnectTimer, &QTimer::timeout,
                 this, &AirPodsTrayApp::attemptControlReconnect);
 
-        // Its bounded retries (m_retryAttempts) can still exhaust with BlueZ sitting on
-        // Connected the whole time (no transition ever arrives to retrigger recovery) -
-        // this periodic check is the fallback for that case. See checkControlLinkWatchdog().
+        // The bounded retries can exhaust while BlueZ still holds the device, and nothing else would fire again.
         m_controlWatchdogTimer = new QTimer(this);
         m_controlWatchdogTimer->setInterval(ControlReconnect::watchdogIntervalMs);
         connect(m_controlWatchdogTimer, &QTimer::timeout,
@@ -932,23 +930,16 @@ private slots:
         }
     }
 
-    // Runs every ControlReconnect::watchdogIntervalMs. scheduleControlReconnect() only
-    // fires from a BlueZ PropertiesChanged transition or a control-socket callback, so once
-    // its bounded retry budget (scheduleControlRecoveryRetry -> finalizeDeviceDisconnected)
-    // is exhausted, nothing retries again unless one of those events happens to fire - even
-    // though the AirPods can still be sitting connected the whole time. This is the fallback
-    // that notices and tries again, on a slow enough cadence to stay a safety net rather than
-    // a second retry loop racing the bounded one.
+    // Gated on the last probe answer, so pods that are merely away cannot restart the ladder every tick.
     void checkControlLinkWatchdog()
     {
-        if (areAirpodsConnected() || m_controlRecovery.isActive() || m_isSuspending) {
-            return;
-        }
-        if (m_lastAirPodsAddress.isEmpty()) {
+        if (!ControlReconnect::shouldRetryFromWatchdog(
+                areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending,
+                !m_lastAirPodsAddress.isEmpty(), m_bluezReportedConnected)) {
             return;
         }
 
-        LOG_INFO("Control link watchdog: rechecking BlueZ connection state for "
+        LOG_INFO("Control link watchdog: BlueZ still reports the device connected, retrying "
                  << m_lastAirPodsAddress);
         scheduleControlReconnect(m_lastAirPodsAddress, m_lastAirPodsName,
                                  QStringLiteral("watchdog recheck"));
@@ -984,6 +975,7 @@ private slots:
             return;
         }
 
+        m_bluezReportedConnected = connected;
         if (connected) {
             ++m_reconnectAttemptsTotal;
             LOG_INFO("Reconnecting AirPods control link (attempt total="
@@ -1651,6 +1643,8 @@ private:
     QTimer *m_controlReconnectTimer = nullptr;
     // Safety net behind m_controlReconnectTimer's bounded retries; see checkControlLinkWatchdog().
     QTimer *m_controlWatchdogTimer = nullptr;
+    // Last answer BlueZ gave about this device, which is what separates a dead link from absent pods.
+    bool m_bluezReportedConnected = false;
     QSettings *m_settings;
     AutoStartManager *m_autoStartManager;
     int m_retryAttempts = 3;

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -28,6 +28,21 @@ private slots:
         QVERIFY(!ControlReconnect::hasAttemptRemaining(0, 0));
     }
 
+    void watchdogStaysSilentUnlessBluezStillHoldsTheDevice()
+    {
+        // Pods merely away: BlueZ said not connected, so the ladder must not be restarted every tick.
+        QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, false, false, true, false));
+
+        // Issue 19: control socket dead while BlueZ still reports the device connected.
+        QVERIFY(ControlReconnect::shouldRetryFromWatchdog(false, false, false, true, true));
+
+        // Every other guard still vetoes on its own.
+        QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(true, false, false, true, true));
+        QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, true, false, true, true));
+        QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, false, true, true, true));
+        QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, false, false, false, true));
+    }
+
     void tracksRecoveryLifecycle()
     {
         ControlReconnect::Session session;


### PR DESCRIPTION
Fixes #19

## Reproduction

Captured on real hardware: a control-link recovery exhausted its 3 bounded attempts (`AirPods control recovery exhausted for "..."`) while `bluetoothctl info` continued to report the device `Connected: yes`. `status.json` stayed on `"connected": false` with every battery field unavailable for over 15 minutes, with no further attempt logged, until the daemon was restarted by hand and reconnected within about 2 seconds.

## Fix

Add `checkControlLinkWatchdog()`, polled every `ControlReconnect::watchdogIntervalMs` (30s). It is a no-op unless the control link is down, no recovery is already in flight, and the system is not suspending, in which case it re-enters the existing `scheduleControlReconnect()` path, so it is bound by the same probe/retry machinery instead of a second one.

## What I ran to check it

- `cmake -B build -G Ninja && cmake --build build && ctest --test-dir build`: 17/17 tests pass.
- Installed the built daemon on real hardware and confirmed the watchdog is a silent no-op during normal connected use, no spurious log lines over several minutes of otherwise normal operation.
- Could not force the exact exhaustion-then-recover window on demand for an after-the-fix capture, it depends on the same BlueZ timing race as #18. The watchdog re-enters `scheduleControlReconnect()`, the same path exercised by the existing control-link recovery tests and by real disconnect/reconnect events, rather than introducing new untested logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnection recovery for connected devices when the control link is lost.
  * Added watchdog-based retry checks to avoid unnecessary recovery attempts for unavailable devices or during suspension.
  * Improved handling of separate retry limits for connected and unavailable devices.
  * Capped retry delays to prevent excessively long waits.
  * Added periodic monitoring to resume recovery when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->