### PR TITLE
fix: read MPRIS PlaybackStatus without introspection

### DIFF
--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -433,17 +433,6 @@ QStringList MediaController::getPlayingMediaPlayers()
       continue;
     }
 
-    QDBusInterface playerInterface(
-        service,
-        "/org/mpris/MediaPlayer2",
-        "org.mpris.MediaPlayer2.Player",
-        bus);
-
-    if (!playerInterface.isValid())
-    {
-      continue;
-    }
-
     if (PlayerStatusWatcher::playbackStatusOf(service) == "Playing")
     {
       playingServices << service;

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -444,8 +444,7 @@ QStringList MediaController::getPlayingMediaPlayers()
       continue;
     }
 
-    QVariant playbackStatus = playerInterface.property("PlaybackStatus");
-    if (playbackStatus.isValid() && playbackStatus.toString() == "Playing")
+    if (PlayerStatusWatcher::playbackStatusOf(service) == "Playing")
     {
       playingServices << service;
       LOG_DEBUG("Found playing service: " << service);
@@ -529,9 +528,9 @@ void MediaController::pause()
       continue;
     }
 
-    QVariant playbackStatus = playerInterface.property("PlaybackStatus");
-    LOG_DEBUG("PlaybackStatus for " << service << ": " << playbackStatus.toString());
-    if (!playbackStatus.isValid() || playbackStatus.toString() != "Playing")
+    const QString playbackStatus = PlayerStatusWatcher::playbackStatusOf(service);
+    LOG_DEBUG("PlaybackStatus for " << service << ": " << playbackStatus);
+    if (playbackStatus != "Playing")
     {
       continue;
     }

--- a/daemon/media/playerstatuswatcher.cpp
+++ b/daemon/media/playerstatuswatcher.cpp
@@ -54,8 +54,6 @@ void PlayerStatusWatcher::onServiceOwnerChanged(const QString &name, const QStri
 
 QString PlayerStatusWatcher::playbackStatusOf(const QString &playerService)
 {
-    if (playerService.isEmpty()) return QString();
-
     QDBusInterface props(playerService, "/org/mpris/MediaPlayer2",
                          "org.freedesktop.DBus.Properties", QDBusConnection::sessionBus());
     if (!props.isValid()) return QString();

--- a/daemon/media/playerstatuswatcher.cpp
+++ b/daemon/media/playerstatuswatcher.cpp
@@ -52,33 +52,32 @@ void PlayerStatusWatcher::onServiceOwnerChanged(const QString &name, const QStri
     }
 }
 
+QString PlayerStatusWatcher::playbackStatusOf(const QString &playerService)
+{
+    if (playerService.isEmpty()) return QString();
+
+    QDBusInterface props(playerService, "/org/mpris/MediaPlayer2",
+                         "org.freedesktop.DBus.Properties", QDBusConnection::sessionBus());
+    if (!props.isValid()) return QString();
+
+    QDBusReply<QVariant> reply = props.call("Get", "org.mpris.MediaPlayer2.Player", "PlaybackStatus");
+    if (!reply.isValid()) return QString();
+
+    return reply.value().toString();
+}
+
 QString PlayerStatusWatcher::getCurrentPlaybackStatus(const QString &playerService)
 {
-    QDBusConnection bus = QDBusConnection::sessionBus();
-
     // If a specific player was requested, query only that one.
-    if (!playerService.isEmpty()) {
-        QDBusInterface iface(playerService, "/org/mpris/MediaPlayer2",
-                             "org.mpris.MediaPlayer2.Player", bus);
-        if (iface.isValid()) {
-            QVariant status = iface.property("PlaybackStatus");
-            if (status.isValid()) return status.toString();
-        }
-        return QString();
-    }
+    if (!playerService.isEmpty()) return playbackStatusOf(playerService);
 
     // Otherwise pick the most-active player. Priority: Playing > Paused >
     // anything else (Stopped/empty).
     QString fallback;
-    QStringList services = bus.interface()->registeredServiceNames().value();
+    QStringList services = QDBusConnection::sessionBus().interface()->registeredServiceNames().value();
     for (const QString &service : services) {
         if (!service.startsWith("org.mpris.MediaPlayer2.")) continue;
-        QDBusInterface iface(service, "/org/mpris/MediaPlayer2",
-                             "org.mpris.MediaPlayer2.Player", bus);
-        if (!iface.isValid()) continue;
-        QVariant status = iface.property("PlaybackStatus");
-        if (!status.isValid()) continue;
-        QString s = status.toString();
+        const QString s = playbackStatusOf(service);
         if (s == "Playing") return s;
         if (s == "Paused" && fallback.isEmpty()) fallback = s;
     }

--- a/daemon/media/playerstatuswatcher.h
+++ b/daemon/media/playerstatuswatcher.h
@@ -9,8 +9,7 @@ class PlayerStatusWatcher : public QObject {
 public:
     explicit PlayerStatusWatcher(const QString &playerService, QObject *parent = nullptr);
     static QString getCurrentPlaybackStatus(const QString &playerService);
-    // Chromium serves an empty Introspect document, so the metaobject QDBusInterface builds
-    // from it has no PlaybackStatus and property() reads invalid on a player that is Playing.
+    // Chromium serves an empty Introspect document, so property() reads invalid on a player that is Playing.
     static QString playbackStatusOf(const QString &playerService);
 
 signals:

--- a/daemon/media/playerstatuswatcher.h
+++ b/daemon/media/playerstatuswatcher.h
@@ -9,6 +9,9 @@ class PlayerStatusWatcher : public QObject {
 public:
     explicit PlayerStatusWatcher(const QString &playerService, QObject *parent = nullptr);
     static QString getCurrentPlaybackStatus(const QString &playerService);
+    // Chromium serves an empty Introspect document, so the metaobject QDBusInterface builds
+    // from it has no PlaybackStatus and property() reads invalid on a player that is Playing.
+    static QString playbackStatusOf(const QString &playerService);
 
 signals:
     void playbackStatusChanged(const QString &status);


### PR DESCRIPTION
## What goes wrong

Ear detection is set to pause when one pod is removed (`earDetection/setting=0`) and it works for Spotify, but a video playing in Chromium keeps going. It only stops when both pods come out, and that is not the pause path at all: `removeAudioOutputDevice()` sets the card profile to `off`, the sink disappears, and Chromium stops itself.

## Why

Chromium answers `Introspect` with an empty document:

```
$ busctl --user call org.mpris.MediaPlayer2.chromium.instance11591 \
    /org/mpris/MediaPlayer2 org.freedesktop.DBus.Introspectable Introspect
s "<!DOCTYPE node PUBLIC ...>\n<node>\n</node>\n"
```

`QDBusInterface` builds its metaobject from that document, so for Chromium it carries no properties and `property("PlaybackStatus")` returns an invalid QVariant while the player is plainly Playing. `MediaController::pause()` and `PlayerStatusWatcher::getCurrentPlaybackStatus()` both read the status that way, so Chromium is skipped in the pause loop, and with Chromium as the only player `getCurrentMediaState()` never returns Playing, so `handleEarDetection()` does not even reach `pause()`.

Spotify ships a normal introspection document, which is why it was never affected.

Standalone reproduction, no AirPods needed:

<details>
<summary>repro.cpp</summary>

```cpp
// g++ repro.cpp -o repro $(pkg-config --cflags --libs Qt6DBus Qt6Core)
#include <QCoreApplication>
#include <QDBusConnection>
#include <QDBusConnectionInterface>
#include <QDBusInterface>
#include <QDBusReply>
#include <cstdio>

int main(int argc, char **argv) {
  QCoreApplication app(argc, argv);
  QDBusConnection bus = QDBusConnection::sessionBus();
  for (const QString &service : bus.interface()->registeredServiceNames().value()) {
    if (!service.startsWith("org.mpris.MediaPlayer2.")) continue;
    QDBusInterface iface(service, "/org/mpris/MediaPlayer2",
                         "org.mpris.MediaPlayer2.Player", bus);
    QVariant viaProperty = iface.property("PlaybackStatus");
    QDBusInterface props(service, "/org/mpris/MediaPlayer2",
                         "org.freedesktop.DBus.Properties", bus);
    QDBusReply<QVariant> viaGet =
        props.call("Get", "org.mpris.MediaPlayer2.Player", "PlaybackStatus");
    printf("%s\n  isValid=%d  property()=[%s]  Properties.Get=[%s]\n",
           qPrintable(service), (int)iface.isValid(),
           qPrintable(viaProperty.toString()), qPrintable(viaGet.value().toString()));
  }
  return 0;
}
```
</details>

With a video playing in Chromium:

```
org.mpris.MediaPlayer2.chromium.instance11591
  isValid=1  property()=[]  Properties.Get=[Playing]
```

## The fix

Read the property with a direct `org.freedesktop.DBus.Properties.Get`, which needs no introspection, and route the three status reads through it. Method calls were never affected, because `call("Pause")` goes out as a message without consulting the metaobject, so `pause()` and `play()` are otherwise unchanged.

## What I ran

Arch Linux, Qt 6.11.1, PipeWire with WirePlumber, Chromium on Wayland, AirPods Pro 3 (A3047).

Before, unpatched daemon with `QT_LOGGING_RULES="openpods.debug=true"`, one pod removed while Chromium was playing:

```
Playback status changed:  "Playing"
Parsed Ear Detection Status: Primary - InEar , Secondary - NotInEar
Ear detection status: primaryInEar= true , secondaryInEar= false , isAirPodsActive= true
At least one AirPod is in ear
```

No `Pausing playback for ear detection` and no `Paused playback for`. The video kept playing.

After, same hardware and same gesture:

```
Paused playback for:  "org.mpris.MediaPlayer2.chromium.instance11591"
Paused  1  media player(s) via DBus
Resumed playback for:  "org.mpris.MediaPlayer2.chromium.instance11591"
Resumed  1  media player(s) via DBus
```

Resume on reinsert works now too, which it never did for Chromium, since nothing was being recorded in `pausedByAppServices`.

`ctest --test-dir build`: 100% tests passed, 18 out of 18.

## On a failing test case

I could not add one to the suite. `openpods_add_test` links only `Qt6::Test` and `Qt6::Core`, so a case that stands up a D-Bus service cannot run there, and the defect sits in `mediacontroller.cpp` and `playerstatuswatcher.cpp`, which CONTRIBUTING.md notes have no direct tests for exactly that reason. The program above is the deterministic reproduction instead. It goes from `property()=[]` to agreeing with `Properties.Get` on any machine with Chromium running.

## Upstream

librepods carries the same code and the same defect, so I have sent the equivalent patch there as well, librepods-org/librepods#741. Worth noting its Rust rewrite already reads the property with `Properties::get`, so this only ever affected the Qt tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media playback status detection for players with limited D-Bus introspection support.
  * More reliably identifies currently playing and paused media services.
  * Improved selection of media players when pausing playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->