### PR TITLE
fix: rescan BlueZ when the daemon starts before the adapter

### DIFF
--- a/daemon/BluetoothMonitor.cpp
+++ b/daemon/BluetoothMonitor.cpp
@@ -82,9 +82,13 @@ bool BluetoothMonitor::checkAlreadyConnectedDevices()
 
     if (reply.type() == QDBusMessage::ErrorMessage)
     {
-        LOG_WARN("Failed to get managed objects: " << reply.errorMessage());
+        if (!m_sweepFailureLogged) {
+            LOG_WARN("Failed to get managed objects: " << reply.errorMessage());
+            m_sweepFailureLogged = true;
+        }
         return false;
     }
+    m_sweepFailureLogged = false;
 
     QVariant firstArg = reply.arguments().constFirst();
     QDBusArgument arg = firstArg.value<QDBusArgument>();

--- a/daemon/BluetoothMonitor.cpp
+++ b/daemon/BluetoothMonitor.cpp
@@ -5,6 +5,10 @@
 #include <QDBusObjectPath>
 #include <QDBusMetaType>
 
+// bluetoothd answers this sweep in milliseconds, and the watchdog repeats it, so a wedged
+// bluetoothd must not hold the event loop for the 25 s D-Bus default on every tick.
+static constexpr int sweepTimeoutMs = 2000;
+
 BluetoothMonitor::BluetoothMonitor(QObject *parent)
     : QObject(parent), m_dbus(QDBusConnection::systemBus())
 {
@@ -70,8 +74,11 @@ QString BluetoothMonitor::getDeviceName(const QString &devicePath)
 
 bool BluetoothMonitor::checkAlreadyConnectedDevices()
 {
-    QDBusInterface objectManager("org.bluez", "/", "org.freedesktop.DBus.ObjectManager", m_dbus);
-    QDBusMessage reply = objectManager.call("GetManagedObjects");
+    // QDBusInterface introspects the remote object from its constructor on the default 25 s
+    // timeout, so setTimeout on the interface cannot bound this. Build the call directly.
+    QDBusMessage request = QDBusMessage::createMethodCall(
+        "org.bluez", "/", "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+    QDBusMessage reply = m_dbus.call(request, QDBus::Block, sweepTimeoutMs);
 
     if (reply.type() == QDBusMessage::ErrorMessage)
     {

--- a/daemon/BluetoothMonitor.h
+++ b/daemon/BluetoothMonitor.h
@@ -32,6 +32,8 @@ private slots:
 
 private:
     QDBusConnection m_dbus;
+    // The watchdog repeats the sweep, so a permanent failure must not repeat its warning.
+    bool m_sweepFailureLogged = false;
     void registerDBusService();
     bool isAirPodsDevice(const QString &devicePath);
     QString getDeviceName(const QString &devicePath);

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -37,6 +37,14 @@ inline bool shouldRetryFromWatchdog(bool controlSocketConnected, bool recoveryAc
            && haveAddress && bluezReportedConnected;
 }
 
+// A cold start before BlueZ has an adapter learns no address, and BlueZ emits no Connected
+// transition for a device whose object is created already connected, so nothing else fires.
+inline bool shouldRescanFromWatchdog(bool controlSocketConnected, bool recoveryActive,
+                                     bool suspending, bool haveAddress)
+{
+    return !controlSocketConnected && !recoveryActive && !suspending && !haveAddress;
+}
+
 inline int delayMs(int attempt, int jitterMs)
 {
     const int boundedAttempt = std::clamp(attempt, 1, maxDoublings);

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -933,6 +933,15 @@ private slots:
     // Gated on the last probe answer, so pods that are merely away cannot restart the ladder every tick.
     void checkControlLinkWatchdog()
     {
+        if (ControlReconnect::shouldRescanFromWatchdog(
+                areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending,
+                !m_lastAirPodsAddress.isEmpty())) {
+            if (monitor->checkAlreadyConnectedDevices()) {
+                LOG_INFO("Control link watchdog: swept up AirPods that no BlueZ signal announced");
+            }
+            return;
+        }
+
         if (!ControlReconnect::shouldRetryFromWatchdog(
                 areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending,
                 !m_lastAirPodsAddress.isEmpty(), m_bluezReportedConnected)) {

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -43,6 +43,21 @@ private slots:
         QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, false, false, false, true));
     }
 
+    void watchdogSweepsBlueZWhenTheDaemonStartedBeforeTheAdapter()
+    {
+        // Cold start with the adapter down: no address was ever learned, so the retry ladder cannot run.
+        QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, false, false, false, false));
+        QVERIFY(ControlReconnect::shouldRescanFromWatchdog(false, false, false, false));
+
+        // An address in hand means the retry ladder owns the tick, so the sweep stands down.
+        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, false, false, true));
+
+        // Every other guard still vetoes on its own.
+        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(true, false, false, false));
+        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, true, false, false));
+        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, false, true, false));
+    }
+
     void tracksRecoveryLifecycle()
     {
         ControlReconnect::Session session;


### PR DESCRIPTION
Part of #24. See "What this does not close" below for why it is not the whole issue.

## The fix

The 30 s control watchdog already runs. On any tick where the daemon holds no address, it now calls `BluetoothMonitor::checkAlreadyConnectedDevices()` instead of returning. A daemon that started before the adapter picks the AirPods up on the next tick, rather than waiting for a manual restart.

The gate is a new pure predicate next to the existing one, `ControlReconnect::shouldRescanFromWatchdog`, so the suite can cover it. The tick stands down as soon as an address is known, which leaves the retry ladder in charge of every case it already owned.

Three commits:

1. `6084e04` the watchdog rescan itself.
2. `1df0da5` bound the sweep. It is blocking and now repeated, so it must not hold the event loop on a wedged bluetoothd.
3. `db6462f` log a failed sweep once rather than every 30 s.

## Bounding the sweep

The obvious `QDBusInterface::setTimeout()` does not work, because `QDBusInterface` introspects the remote object from its own constructor before `setTimeout` can run, on the default 25 s timeout. Measured with a Qt 6.11.2 client against a bus name that never replies:

| step | blocking time |
| --- | --- |
| `QDBusInterface` constructor | 24800 ms |
| `.call()` after `setTimeout(2000)` | 1996 ms |
| total | 26796 ms |
| `createMethodCall` plus `bus.call(QDBus::Block, 2000)` | 1999 ms |

The sweep builds the message directly, so there is one bounded round trip and no introspection.

## Reproduction

Script is in the issue. `GetManagedObjects` is the call the sweep makes, so counting it counts sweeps. Adapter down at daemon start, back up after 10 s, then 95 s of observation.

| build | sweeps before the adapter returned | sweeps in the 95 s after |
| --- | --- | --- |
| v1.2.0-12-g36e51b4 | 6 | 0 |
| this branch | 6 | 3 |

Three sweeps is one per watchdog tick, which is what the fix is meant to produce.

## On hardware

- Stock v1.2.0-12-g36e51b4, daemon already running with the adapter up, pods put in ears: they reconnected on their own and the panel filled in correctly, left 100%, right 100%, case 90%, both in ear. The ordinary `PropertiesChanged` path is healthy, which narrows this bug to the adapter teardown case rather than to reconnects in general.
- This branch, pods connected: the sweep finds them and the daemon reads the pods, battery and ear detection correctly, with no D-Bus warnings.

Machine: Arch Linux, BlueZ 5.87, Qt 6.11.2, AirPods Pro 2.

## What this does not close

Only the worn pods path. If the adapter is down at daemon start and the pods are left in the case, the panel still shows nothing, because in-case pods are not `Connected` and the sweep only reports connected devices. That state is served by BLE advertisements, and BLE discovery is dead by then: `initializeBluetooth()` starts the scan, it fails with `PoweredOffError`, and `BleManager::onErrorOccurred` calls `stopScan()` with no retry. Nothing rearms it until a full wear, connect and disconnect cycle.

That is why this says "Part of #24" and not "Fixes". The BLE retry is a separate concern and is not in this diff. Happy to send it as a second PR if you want it.

## What I ran

- `cmake -B build -G Ninja && cmake --build build && ctest --test-dir build`: 18/18 pass on every commit.
- The new test case is red without the fix. Reverting only `controlreconnect.hpp` and `main.cpp` and rebuilding gives `error: 'shouldRescanFromWatchdog' is not a member of 'ControlReconnect'`.
- The sweep measurement and the timeout measurement above, both on the box.

## Not yet driven in a single run

I have not run the whole sequence in one go: adapter down at daemon start, adapter back up, pods reconnecting, and the panel filling in from a watchdog sweep rather than from the constructor. Both halves are measured above, but not chained. Say the word and I will run it and post the log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bluetooth device recovery when the control connection is unavailable.
  - The daemon now checks previously connected devices before retrying, helping restore connectivity faster.
  - Improved startup behavior when the Bluetooth adapter becomes available after launch.
  - Added safeguards to avoid unnecessary rescans during recovery or system suspension.
  - Improved responsiveness when checking for connected Bluetooth devices.
  - Reduced repeated warning messages when device checks temporarily fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->