### PR TITLE
fix: keep the headset profile while a capture is live

### DIFF
--- a/daemon/media/capturematch.hpp
+++ b/daemon/media/capturematch.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QString>
+
+// What PulseAudio could tell us about a capture on the AirPods.
+enum class CaptureState { Idle, Live, Unknown };
+
+// Sample inputs: "bluez_input.AA:BB:CC:DD:EE:FF" (WirePlumber loopback) and
+// "bluez_input.AA_BB_CC_DD_EE_FF.0" (direct node), against a "AA_BB_CC_DD_EE_FF" address.
+inline bool sourceNamesAddress(const QString &sourceName, const QString &macAddress)
+{
+    if (sourceName.isEmpty() || macAddress.isEmpty()) {
+        return false;
+    }
+    return QString(sourceName).remove(':').remove('_').contains(QString(macAddress).remove(':').remove('_'));
+}
+
+// Counted separately from the activation attempts, because a call that outlasts them must not
+// spend that budget, and only Unknown means PulseAudio failed to answer.
+inline int unansweredChecksAfter(CaptureState state, int unanswered)
+{
+    return state == CaptureState::Unknown ? unanswered + 1 : 0;
+}

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -1,4 +1,5 @@
 #include "mediacontroller.h"
+#include "capturematch.hpp"
 #include "logger.h"
 #include "eardetection.hpp"
 #include "playerstatuswatcher.h"
@@ -349,19 +350,40 @@ void MediaController::cancelPendingA2dpActivation() {
   ++m_a2dpRetryGeneration;
 }
 
-void MediaController::attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt) {
+void MediaController::attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt, int unanswered) {
+  static constexpr int kMaxAttempts = 6;
+  static constexpr int kDelayMs = 1500;
+  static constexpr int kCaptureRecheckMs = 10000;
+  static constexpr int kMaxUnansweredChecks = 6;
+
   // A newer request or a disconnect superseded this chain, so it must not restore a stale device.
   if (generation != m_a2dpRetryGeneration) return;
 
   // PipeWire publishes the bluez5 card asynchronously, so the first attempts commonly find nothing.
   setConnectedDeviceMacAddress(macAddress);
+
+  // Switching under a live capture cuts the mic, and no other timer re-arms this ladder.
+  const CaptureState capture = m_pulseAudio->captureState(connectedDeviceMacAddress);
+  if (capture != CaptureState::Idle) {
+    const int nextUnanswered = unansweredChecksAfter(capture, unanswered);
+    if (nextUnanswered >= kMaxUnansweredChecks) {
+      LOG_ERROR("Giving up on A2DP profile activation for " << macAddress
+                << ", the capture query came back unknown " << nextUnanswered << " times running");
+      return;
+    }
+    LOG_INFO("Capture " << (capture == CaptureState::Live ? "live" : "unknown")
+             << " on the AirPods, re-checking in " << kCaptureRecheckMs << "ms");
+    QTimer::singleShot(kCaptureRecheckMs, this, [this, macAddress, generation, attempt, nextUnanswered]() {
+      attemptA2dpActivation(macAddress, generation, attempt, nextUnanswered);
+    });
+    return;
+  }
+
   if (activateA2dpProfile()) {
     LOG_INFO("A2DP profile activated (attempt " << (attempt + 1) << ")");
     return;
   }
 
-  static constexpr int kMaxAttempts = 6;
-  static constexpr int kDelayMs = 1500;
   if (attempt + 1 >= kMaxAttempts) {
     LOG_ERROR("Giving up on A2DP profile activation after " << kMaxAttempts << " attempts");
     return;

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -60,7 +60,7 @@ private:
   QStringList getPlayingMediaPlayers();
   // Only the retry chain calls this, so the one-restart flag below cannot be read outside a chain.
   bool activateA2dpProfile();
-  void attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt);
+  void attemptA2dpActivation(const QString &macAddress, quint64 generation, int attempt, int unanswered = 0);
 
   QStringList pausedByAppServices;
   int initialVolume = -1;

--- a/daemon/media/pulseaudiocontroller.cpp
+++ b/daemon/media/pulseaudiocontroller.cpp
@@ -1,4 +1,5 @@
 #include "pulseaudiocontroller.h"
+#include "capturematch.hpp"
 #include "logger.h"
 #include "../snaptogrid.hpp"
 #include <QElapsedTimer>
@@ -416,6 +417,83 @@ bool PulseAudioController::isProfileAvailable(const QString &cardName, const QSt
     pa_threaded_mainloop_unlock(m_mainloop);
 
     return data.available;
+}
+
+// A stream attached to the AirPods mic is a call holding the headset profile, and a
+// muted caller still holds it, so both queries run under one lock to see one server state.
+CaptureState PulseAudioController::captureState(const QString &macAddress)
+{
+    // Both are known here rather than unanswered, and the activation path already handles them.
+    if (!m_initialized || macAddress.isEmpty()) return CaptureState::Idle;
+
+    struct SourceData {
+        QVector<uint32_t> indexes;
+        bool failed = false;
+        QString macAddress;
+        pa_threaded_mainloop *mainloop = nullptr;
+    } sources;
+    sources.macAddress = macAddress;
+    sources.mainloop = m_mainloop;
+
+    auto sourceCallback = [](pa_context *, const pa_source_info *info, int eol, void *userdata) {
+        SourceData *d = static_cast<SourceData*>(userdata);
+        if (eol != 0) {
+            if (eol < 0) d->failed = true;
+            pa_threaded_mainloop_signal(d->mainloop, 0);
+            return;
+        }
+        // The card's own monitor carries the same address and runs under music, so it is excluded.
+        if (!info || info->monitor_of_sink != PA_INVALID_INDEX) {
+            return;
+        }
+        if (sourceNamesAddress(QString::fromUtf8(info->name), d->macAddress)) {
+            d->indexes.append(info->index);
+        }
+    };
+
+    struct StreamData {
+        bool capturing = false;
+        bool failed = false;
+        QVector<uint32_t> indexes;
+        pa_threaded_mainloop *mainloop = nullptr;
+    } streams;
+    streams.mainloop = m_mainloop;
+
+    auto streamCallback = [](pa_context *, const pa_source_output_info *info, int eol, void *userdata) {
+        StreamData *d = static_cast<StreamData*>(userdata);
+        if (eol != 0) {
+            if (eol < 0) d->failed = true;
+            pa_threaded_mainloop_signal(d->mainloop, 0);
+            return;
+        }
+        // A corked stream is an app holding the mic open without capturing, which must not pin the card.
+        if (info && !info->corked && d->indexes.contains(info->source)) {
+            d->capturing = true;
+        }
+    };
+
+    pa_threaded_mainloop_lock(m_mainloop);
+    pa_operation *sourceOp = pa_context_get_source_info_list(m_context, sourceCallback, &sources);
+    const bool sourcesWaited = sourceOp != nullptr && waitForOperation(sourceOp);
+    if (sourceOp) {
+        pa_operation_unref(sourceOp);
+    }
+    bool streamsWaited = true;
+    if (sourcesWaited && !sources.failed && !sources.indexes.isEmpty()) {
+        streams.indexes = sources.indexes;
+        pa_operation *streamOp = pa_context_get_source_output_info_list(m_context, streamCallback, &streams);
+        streamsWaited = streamOp != nullptr && waitForOperation(streamOp);
+        if (streamOp) {
+            pa_operation_unref(streamOp);
+        }
+    }
+    pa_threaded_mainloop_unlock(m_mainloop);
+
+    if (!sourcesWaited || sources.failed || !streamsWaited || streams.failed) {
+        LOG_WARN("PulseAudio capture query failed for " << macAddress << ", capture state unknown");
+        return CaptureState::Unknown;
+    }
+    return streams.capturing ? CaptureState::Live : CaptureState::Idle;
 }
 
 QString PulseAudioController::getActiveCardProfile(const QString &cardName)

--- a/daemon/media/pulseaudiocontroller.h
+++ b/daemon/media/pulseaudiocontroller.h
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <pulse/pulseaudio.h>
 
+#include "capturematch.hpp"
+
 class PulseAudioController : public QObject
 {
     Q_OBJECT
@@ -49,6 +51,9 @@ public:
     QString getCardNameForDevice(const QString &macAddress);
     bool isProfileAvailable(const QString &cardName, const QString &profileName);
     QString getActiveCardProfile(const QString &cardName);
+
+    // Live while any stream is attached to this address's mic, which is what a call holds.
+    CaptureState captureState(const QString &macAddress);
 
 private:
     pa_threaded_mainloop *m_mainloop = nullptr;

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -29,6 +29,11 @@ openpods_add_test(tst_autostartmanager
     ../autostartmanager.hpp
 )
 
+openpods_add_test(tst_capturematch
+    tst_capturematch.cpp
+    ../media/capturematch.hpp
+)
+
 openpods_add_test(tst_logger
     tst_logger.cpp
     ../logger.h

--- a/daemon/tests/tst_capturematch.cpp
+++ b/daemon/tests/tst_capturematch.cpp
@@ -1,0 +1,66 @@
+#include <QtTest>
+
+#include "../media/capturematch.hpp"
+
+// Source names in the shape PulseAudio publishes them, with a placeholder address.
+class TestCaptureMatch : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void matchesTheWirePlumberLoopbackName();
+    void matchesTheDirectNodeName();
+    void rejectsAnotherDevice();
+    void rejectsEmptyInput();
+    void matchesTheMonitorNameToo();
+    void anAnsweredQueryClearsTheUnansweredCount();
+    void onlyAnUnknownQuerySpendsTheUnansweredCount();
+};
+
+void TestCaptureMatch::matchesTheWirePlumberLoopbackName()
+{
+    QVERIFY(sourceNamesAddress("bluez_input.AA:BB:CC:DD:EE:FF", "AA_BB_CC_DD_EE_FF"));
+}
+
+void TestCaptureMatch::matchesTheDirectNodeName()
+{
+    QVERIFY(sourceNamesAddress("bluez_input.AA_BB_CC_DD_EE_FF.0", "AA_BB_CC_DD_EE_FF"));
+}
+
+void TestCaptureMatch::rejectsAnotherDevice()
+{
+    QVERIFY(!sourceNamesAddress("bluez_input.11_22_33_44_55_66", "AA_BB_CC_DD_EE_FF"));
+    QVERIFY(!sourceNamesAddress("alsa_input.pci-0000_00_1f.3.analog-stereo", "AA_BB_CC_DD_EE_FF"));
+}
+
+void TestCaptureMatch::rejectsEmptyInput()
+{
+    // Both empty is the load-bearing case: QString::contains("") is true without the guard.
+    QVERIFY(!sourceNamesAddress("", ""));
+    QVERIFY(!sourceNamesAddress("bluez_input.AA:BB:CC:DD:EE:FF", ""));
+    QVERIFY(!sourceNamesAddress("", "AA_BB_CC_DD_EE_FF"));
+}
+
+void TestCaptureMatch::matchesTheMonitorNameToo()
+{
+    // A match means the address, not a capture, so the caller's monitor_of_sink filter is load-bearing.
+    QVERIFY(sourceNamesAddress("bluez_output.AA_BB_CC_DD_EE_FF.1.monitor", "AA_BB_CC_DD_EE_FF"));
+}
+
+void TestCaptureMatch::anAnsweredQueryClearsTheUnansweredCount()
+{
+    // Live and Idle are both answers, so neither may walk a long call towards the give-up path.
+    QCOMPARE(unansweredChecksAfter(CaptureState::Live, 0), 0);
+    QCOMPARE(unansweredChecksAfter(CaptureState::Live, 5), 0);
+    QCOMPARE(unansweredChecksAfter(CaptureState::Idle, 5), 0);
+}
+
+void TestCaptureMatch::onlyAnUnknownQuerySpendsTheUnansweredCount()
+{
+    // Otherwise a PulseAudio that never answers re-checks forever instead of giving up.
+    QCOMPARE(unansweredChecksAfter(CaptureState::Unknown, 0), 1);
+    QCOMPARE(unansweredChecksAfter(CaptureState::Unknown, 5), 6);
+}
+
+QTEST_GUILESS_MAIN(TestCaptureMatch)
+#include "tst_capturematch.moc"


### PR DESCRIPTION
Fixes #23.

Captured live: card on `headset-head-unit` with a call capturing from `bluez_input`, a daemon restart logged `Profile activated: "a2dp-sink-sbc_xq"` and the mic went silent for several seconds before WirePlumber's autoswitch pulled the card back.

The guard keys on a RUNNING non-monitor source for the device, not on the profile name, and sits at `attemptA2dpActivation`, the one funnel every caller already goes through. Matching is by address because pipewire-pulse reports no card on any source, so a card-index match would never fire.

Proven on minipc: with a capture live on the AirPods the card stays on `headset-head-unit` and the daemon logs `Capture is live on the AirPods, leaving the headset profile alone`; with the capture on the analog mic instead, A2DP activates normally and the guard stays quiet. Build rc=0, 0 warnings, ctest 18/18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented A2DP profile activation while headset microphone capture is active or cannot be reliably determined.
  * Preserved the current headset profile during active capture to avoid disrupting audio input.
  * Improved detection of running headset capture sources while ignoring monitor sources.
  * Added controlled retries for temporary capture-state uncertainty, with activation eventually stopping if the state remains unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->