### PR TITLE
fix: stop overriding the codec, and rank by bitrate when choosing

### DIFF
--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -1,5 +1,6 @@
 #include "mediacontroller.h"
 #include "capturematch.hpp"
+#include "profilechoice.hpp"
 #include "logger.h"
 #include "eardetection.hpp"
 #include "playerstatuswatcher.h"
@@ -200,34 +201,9 @@ void MediaController::handleConversationalAwareness(const QByteArray &data) {
 }
 
 
-// AirPods support AAC over A2DP (256kbps, ~Apple's max codec rate over BT
-// Classic). Apple Lossless is NOT a Bluetooth-transmittable codec — it
-// requires H2-to-H2 link (Vision Pro / AirPods Max USB-C), unreachable
-// from Linux. So AAC is the ceiling for output quality. LE Audio (LC3) is
-// preferred for duplex (high-quality mic + output) when PipeWire ≥1.2 +
-// BlueZ ≥5.66 advertise BAP profiles. SBC XQ is a fallback that beats
-// vanilla SBC. SBC is last resort.
+// Available when the card offers any playback profile at all.
 bool MediaController::isA2dpProfileAvailable() {
-  if (m_deviceOutputName.isEmpty()) {
-    return false;
-  }
-
-  static const QStringList kHighQualityProfiles = {
-      // LE Audio (PipeWire / BlueZ experimental BAP)
-      "bap-sink",
-      "bap-headset",
-      // Classic A2DP, best codec first
-      "a2dp-sink-aac",
-      "a2dp-sink-sbc_xq",
-      "a2dp-sink-sbc",
-      "a2dp-sink",
-  };
-  for (const QString &p : kHighQualityProfiles) {
-    if (m_pulseAudio->isProfileAvailable(m_deviceOutputName, p)) {
-      return true;
-    }
-  }
-  return false;
+  return !getPreferredA2dpProfile().isEmpty();
 }
 
 QString MediaController::getPreferredA2dpProfile() {
@@ -240,25 +216,14 @@ QString MediaController::getPreferredA2dpProfile() {
     return m_cachedA2dpProfile;
   }
 
-  static const QStringList kProfilesByPreference = {
-      "bap-sink",
-      "bap-headset",
-      "a2dp-sink-aac",
-      "a2dp-sink-sbc_xq",
-      "a2dp-sink-sbc",
-      "a2dp-sink",
-  };
-
-  for (const QString &profile : kProfilesByPreference) {
-    if (m_pulseAudio->isProfileAvailable(m_deviceOutputName, profile)) {
-      LOG_INFO("Selected best available output profile: " << profile);
-      m_cachedA2dpProfile = profile;
-      return profile;
-    }
+  const QVector<ProfileCandidate> profiles = m_pulseAudio->getCardProfiles(m_deviceOutputName);
+  m_cachedA2dpProfile = bestPlaybackProfile(profiles);
+  if (!m_cachedA2dpProfile.isEmpty()) {
+    // The profile name hides the codec: AAC is the bare `a2dp-sink` on this stack.
+    LOG_INFO("Selected best available output profile: " << m_cachedA2dpProfile
+             << " (" << profileDescription(profiles, m_cachedA2dpProfile) << ")");
   }
-
-  m_cachedA2dpProfile.clear();
-  return QString();
+  return m_cachedA2dpProfile;
 }
 
 bool MediaController::restartWirePlumber() {
@@ -307,10 +272,10 @@ bool MediaController::activateA2dpProfile() {
     return false;
   }
 
-  // Re-applying the profile WirePlumber already set tears down the live sink under a playing stream.
+  // Re-applying the profile already in place tears the live sink down under a playing stream.
   const QString activeProfile = m_pulseAudio->getActiveCardProfile(m_deviceOutputName);
   if (activeProfile == preferredProfile) {
-    LOG_INFO("A2DP profile already active: " << activeProfile);
+    LOG_INFO("Best profile already active: " << activeProfile);
   } else {
     LOG_INFO("Activating best output profile: " << preferredProfile);
     if (!m_pulseAudio->setCardProfile(m_deviceOutputName, preferredProfile)) {
@@ -320,12 +285,7 @@ bool MediaController::activateA2dpProfile() {
     LOG_INFO("Profile activated: " << preferredProfile);
   }
 
-  // After A2DP activation the AirPods sink is live + selected as
-  // default. Enable AVRCP 5%-grid snap on it now. AirPods stem-
-  // swipes write 1/15 (~6.67%) increments via AVRCP AbsoluteVolume;
-  // the snap callback in PulseAudioController rounds those back to
-  // the 5% grid so the user gets uniform 5/10/15/... steps that
-  // match Quickshell's keyboard-volume behavior.
+  // AirPods stem swipes write 1/15 steps over AVRCP, so snap them onto the 5% grid.
   QString sink = m_pulseAudio->getDefaultSink();
   if (!sink.isEmpty() && sink.contains(connectedDeviceMacAddress)) {
     m_pulseAudio->enableVolumeSnap(sink, 5);

--- a/daemon/media/profilechoice.hpp
+++ b/daemon/media/profilechoice.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+
+// Free of PulseAudio types so the choice below is testable without a sound server.
+struct ProfileCandidate {
+    QString name;
+    QString description;
+    int priority = 0;
+    bool available = false;
+    unsigned sinks = 0;
+    unsigned sources = 0;
+};
+
+// corner: only these three reach a playback profile; MSBC and CVSD belong to the headset ones.
+inline int codecBitrateKbps(const QString &codec)
+{
+    if (codec == "SBC-XQ") return 453;
+    if (codec == "SBC") return 328;
+    if (codec == "AAC") return 256;
+    return 0;
+}
+
+// Sample input: "High Fidelity Playback (A2DP Sink, codec SBC-XQ)"
+inline QString codecFromDescription(const QString &description)
+{
+    static const QString marker = "codec ";
+    const int at = description.indexOf(marker);
+    if (at < 0) {
+        return QString();
+    }
+    const QString rest = description.mid(at + marker.length());
+    const int end = rest.indexOf(')');
+    return (end >= 0 ? rest.left(end) : rest).trimmed();
+}
+
+// Sample input: "a2dp-sink-sbc_xq". Names are identifiers, so they survive a translated locale.
+inline QString codecFromProfileName(const QString &name)
+{
+    const int dash = name.lastIndexOf('-');
+    if (dash < 0) {
+        return QString();
+    }
+    const QString suffix = name.mid(dash + 1);
+    // The bare a2dp-sink carries no codec suffix, and a headset profile's tail is not one either.
+    if (suffix == "sink" || suffix == "source" || suffix == "unit" || suffix == "headset") {
+        return QString();
+    }
+    return suffix.toUpper().replace('_', '-');
+}
+
+// Description PulseAudio gave this profile, empty when the card does not have it.
+inline QString profileDescription(const QVector<ProfileCandidate> &candidates, const QString &name)
+{
+    for (const ProfileCandidate &c : candidates) {
+        if (c.name == name) {
+            return c.description;
+        }
+    }
+    return QString();
+}
+
+// A profile carrying a source is the headset mic path, never the playback one.
+inline QString bestPlaybackProfile(const QVector<ProfileCandidate> &candidates)
+{
+    QString best;
+    int bestBitrate = -1;
+    int bestPriority = -1;
+    for (const ProfileCandidate &c : candidates) {
+        if (!c.available || c.sinks == 0 || c.sources > 0) {
+            continue;
+        }
+        // The name survives a translated locale, so it is tried first and the description backs it up.
+        int bitrate = codecBitrateKbps(codecFromProfileName(c.name));
+        if (bitrate == 0) {
+            bitrate = codecBitrateKbps(codecFromDescription(c.description));
+        }
+        if (bitrate > bestBitrate || (bitrate == bestBitrate && c.priority > bestPriority)) {
+            bestBitrate = bitrate;
+            bestPriority = c.priority;
+            best = c.name;
+        }
+    }
+    return best;
+}

--- a/daemon/media/pulseaudiocontroller.cpp
+++ b/daemon/media/pulseaudiocontroller.cpp
@@ -1,5 +1,6 @@
 #include "pulseaudiocontroller.h"
 #include "capturematch.hpp"
+#include "profilechoice.hpp"
 #include "logger.h"
 #include "../snaptogrid.hpp"
 #include <QElapsedTimer>
@@ -494,6 +495,62 @@ CaptureState PulseAudioController::captureState(const QString &macAddress)
         return CaptureState::Unknown;
     }
     return streams.capturing ? CaptureState::Live : CaptureState::Idle;
+}
+
+QVector<ProfileCandidate> PulseAudioController::getCardProfiles(const QString &cardName)
+{
+    if (!m_initialized || cardName.isEmpty()) {
+        LOG_WARN("No card to query for profiles, name=" << cardName << " initialized=" << m_initialized);
+        return {};
+    }
+
+    struct CallbackData {
+        QVector<ProfileCandidate> candidates;
+        bool failed = false;
+        QString targetCard;
+        pa_threaded_mainloop *mainloop = nullptr;
+    } data;
+    data.targetCard = cardName;
+    data.mainloop = m_mainloop;
+
+    auto callback = [](pa_context *, const pa_card_info *info, int eol, void *userdata) {
+        CallbackData *d = static_cast<CallbackData*>(userdata);
+        // PulseAudio completes the operation even on an error, so record the negative eol.
+        if (eol != 0) {
+            if (eol < 0) d->failed = true;
+            pa_threaded_mainloop_signal(d->mainloop, 0);
+            return;
+        }
+        if (!info || QString::fromUtf8(info->name) != d->targetCard || !info->profiles2) {
+            return;
+        }
+        // profiles2 is a null-terminated array of pointers, unlike the flat profiles list.
+        for (pa_card_profile_info2 **p = info->profiles2; *p; ++p) {
+            d->candidates.append(ProfileCandidate{
+                QString::fromUtf8((*p)->name),
+                QString::fromUtf8((*p)->description ? (*p)->description : ""),
+                static_cast<int>((*p)->priority),
+                (*p)->available != 0,
+                (*p)->n_sinks,
+                (*p)->n_sources,
+            });
+        }
+        pa_threaded_mainloop_signal(d->mainloop, 0);
+    };
+
+    pa_threaded_mainloop_lock(m_mainloop);
+    pa_operation *op = pa_context_get_card_info_by_name(
+        m_context, cardName.toUtf8().constData(), callback, &data);
+    const bool queried = op != nullptr && waitForOperation(op);
+    if (op) {
+        pa_operation_unref(op);
+    }
+    pa_threaded_mainloop_unlock(m_mainloop);
+
+    if (!queried || data.failed) {
+        LOG_WARN("PulseAudio card query failed for " << cardName << ", profile list is empty");
+    }
+    return data.candidates;
 }
 
 QString PulseAudioController::getActiveCardProfile(const QString &cardName)

--- a/daemon/media/pulseaudiocontroller.h
+++ b/daemon/media/pulseaudiocontroller.h
@@ -6,6 +6,7 @@
 #include <pulse/pulseaudio.h>
 
 #include "capturematch.hpp"
+#include "profilechoice.hpp"
 
 class PulseAudioController : public QObject
 {
@@ -54,6 +55,8 @@ public:
 
     // Live while any stream is attached to this address's mic, which is what a call holds.
     CaptureState captureState(const QString &macAddress);
+    // Every profile this card reports, for the pure choice in profilechoice.hpp.
+    QVector<ProfileCandidate> getCardProfiles(const QString &cardName);
 
 private:
     pa_threaded_mainloop *m_mainloop = nullptr;

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -34,6 +34,11 @@ openpods_add_test(tst_capturematch
     ../media/capturematch.hpp
 )
 
+openpods_add_test(tst_profilechoice
+    tst_profilechoice.cpp
+    ../media/profilechoice.hpp
+)
+
 openpods_add_test(tst_logger
     tst_logger.cpp
     ../logger.h

--- a/daemon/tests/tst_profilechoice.cpp
+++ b/daemon/tests/tst_profilechoice.cpp
@@ -1,0 +1,159 @@
+#include <QtTest>
+
+#include "../media/profilechoice.hpp"
+
+// Priorities and names here are the ones minipc's AirPods card actually reports.
+class TestProfileChoice : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void picksHighestBitrateNotHighestPriority();
+    void unknownCodecsFallBackToPriority();
+    void skipsHeadsetProfilesThatCarryASource();
+    void skipsUnavailableProfiles();
+    void skipsProfilesWithNoSink();
+    void returnsEmptyWhenNothingQualifies();
+    void readsTheCodecOutOfAProfileDescription();
+    void readsTheCodecOutOfTheProfileNameToo();
+};
+
+static QVector<ProfileCandidate> airPodsCard()
+{
+    return {
+        {"off", "Off", 0, true, 0, 0},
+        {"a2dp-sink-sbc", "High Fidelity Playback (A2DP Sink, codec SBC)", 132, true, 1, 0},
+        {"a2dp-sink-sbc_xq", "High Fidelity Playback (A2DP Sink, codec SBC-XQ)", 131, true, 1, 0},
+        {"a2dp-sink", "High Fidelity Playback (A2DP Sink, codec AAC)", 133, true, 1, 0},
+        {"headset-head-unit-cvsd", "Headset Head Unit (HSP/HFP, codec CVSD)", 5, true, 1, 1},
+        {"headset-head-unit", "Headset Head Unit (HSP/HFP, codec MSBC)", 6, true, 1, 1},
+    };
+}
+
+void TestProfileChoice::picksHighestBitrateNotHighestPriority()
+{
+    // SBC-XQ carries 453kbps against AAC's 256, and PipeWire's priority says the opposite.
+    QCOMPARE(bestPlaybackProfile(airPodsCard()), QString("a2dp-sink-sbc_xq"));
+}
+
+void TestProfileChoice::unknownCodecsFallBackToPriority()
+{
+    // An unknown codec scores 0 bitrate, so PipeWire's priority breaks the tie.
+    QVector<ProfileCandidate> unknownCodecs = {
+        {"vendor-alpha", "Vendor Playback (A2DP Sink, codec MYSTERY)", 12, true, 1, 0},
+        {"vendor-beta", "Vendor Playback (A2DP Sink, codec LDAC)", 99, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(unknownCodecs), QString("vendor-beta"));
+
+    // Same tie the other way round, so an order-sensitive comparison cannot pass both.
+    QVector<ProfileCandidate> unknownCodecsReversed = {
+        {"vendor-beta", "Vendor Playback (A2DP Sink, codec LDAC)", 99, true, 1, 0},
+        {"vendor-alpha", "Vendor Playback (A2DP Sink, codec MYSTERY)", 12, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(unknownCodecsReversed), QString("vendor-beta"));
+
+    // Two candidates equal on bitrate and on priority must resolve the same way either way round.
+    QVector<ProfileCandidate> equalOnBoth = {
+        {"first-seen", "Vendor Playback (A2DP Sink, codec MYSTERY)", 50, true, 1, 0},
+        {"second-seen", "Vendor Playback (A2DP Sink, codec ENIGMA)", 50, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(equalOnBoth), QString("first-seen"));
+    QVector<ProfileCandidate> equalOnBothReversed = {
+        {"second-seen", "Vendor Playback (A2DP Sink, codec ENIGMA)", 50, true, 1, 0},
+        {"first-seen", "Vendor Playback (A2DP Sink, codec MYSTERY)", 50, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(equalOnBothReversed), QString("second-seen"));
+
+    // AAC's own row: it must outscore an unknown codec that outranks it on priority.
+    QVector<ProfileCandidate> aacVersusUnknown = {
+        {"vendor-mystery", "Vendor Playback (A2DP Sink, codec MYSTERY)", 500, true, 1, 0},
+        {"a2dp-sink", "High Fidelity Playback (A2DP Sink, codec AAC)", 133, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(aacVersusUnknown), QString("a2dp-sink"));
+
+    // A known codec always beats an unknown one, whatever the names say.
+    QVector<ProfileCandidate> knownVersusUnknown = {
+        {"zzz-vendor", "Vendor Playback (A2DP Sink, codec MYSTERY)", 500, true, 1, 0},
+        {"aaa-vendor", "High Fidelity Playback (A2DP Sink, codec AAC)", 1, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(knownVersusUnknown), QString("aaa-vendor"));
+}
+
+void TestProfileChoice::skipsHeadsetProfilesThatCarryASource()
+{
+    // Best codec and top priority here, so only the source term can reject the headset.
+    QVector<ProfileCandidate> headsetRanksHighest = {
+        {"headset-head-unit", "Headset Head Unit (HSP/HFP, codec SBC-XQ)", 200, true, 1, 1},
+        {"a2dp-sink", "High Fidelity Playback (A2DP Sink, codec AAC)", 133, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(headsetRanksHighest), QString("a2dp-sink"));
+}
+
+void TestProfileChoice::skipsUnavailableProfiles()
+{
+    QVector<ProfileCandidate> sbcXqUnavailable = airPodsCard();
+    for (ProfileCandidate &c : sbcXqUnavailable) {
+        if (c.name == "a2dp-sink-sbc_xq") c.available = false;
+    }
+    // SBC carries 328kbps, so it outranks AAC's 256 under the same rule.
+    QCOMPARE(bestPlaybackProfile(sbcXqUnavailable), QString("a2dp-sink-sbc"));
+}
+
+void TestProfileChoice::skipsProfilesWithNoSink()
+{
+    // `off` outranks nothing, but a zero-sink profile must never be chosen.
+    // `off` carries the best codec string here so that only the sink term can reject it.
+    QVector<ProfileCandidate> offRanksHighest = {
+        {"off", "Off (A2DP Sink, codec SBC-XQ)", 500, true, 0, 0},
+        {"a2dp-sink", "High Fidelity Playback (A2DP Sink, codec AAC)", 133, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(offRanksHighest), QString("a2dp-sink"));
+    QCOMPARE(codecFromDescription("Headset Head Unit (HSP/HFP, codec MSBC)"), QString("MSBC"));
+    QVERIFY(codecFromDescription("Off").isEmpty());
+}
+
+void TestProfileChoice::returnsEmptyWhenNothingQualifies()
+{
+    QVector<ProfileCandidate> headsetOnly = {
+        {"off", "Off", 0, true, 0, 0},
+        {"headset-head-unit", "Headset Head Unit (HSP/HFP, codec MSBC)", 6, true, 1, 1},
+    };
+    QVERIFY(bestPlaybackProfile(headsetOnly).isEmpty());
+    QVERIFY(bestPlaybackProfile({}).isEmpty());
+}
+
+void TestProfileChoice::readsTheCodecOutOfAProfileDescription()
+{
+    // The profile name hides the codec, so the description is the only place to read it.
+    QCOMPARE(codecFromDescription(profileDescription(airPodsCard(), "a2dp-sink")), QString("AAC"));
+    QCOMPARE(codecFromDescription(profileDescription(airPodsCard(), "a2dp-sink-sbc_xq")), QString("SBC-XQ"));
+    QVERIFY(profileDescription(airPodsCard(), "no-such-profile").isEmpty());
+
+    // A description that never closes its bracket, one with no codec at all, and nothing.
+    QCOMPARE(codecFromDescription("A2DP Sink, codec SBC-XQ"), QString("SBC-XQ"));
+    QVERIFY(codecFromDescription("High Fidelity Playback (A2DP Sink)").isEmpty());
+    QCOMPARE(codecFromDescription("High Fidelity Playback (A2DP Sink, codec SBC-XQ )"), QString("SBC-XQ"));
+    QVERIFY(codecFromDescription("A2DP Sink, codec )").isEmpty());
+    QVERIFY(codecFromDescription(QString()).isEmpty());
+}
+
+void TestProfileChoice::readsTheCodecOutOfTheProfileNameToo()
+{
+    // Descriptions are translated by the server, names are identifiers, so the name comes first.
+    QCOMPARE(codecFromProfileName("a2dp-sink-sbc_xq"), QString("SBC-XQ"));
+    QCOMPARE(codecFromProfileName("a2dp-sink-sbc"), QString("SBC"));
+    QCOMPARE(codecFromProfileName("a2dp-sink-aac"), QString("AAC"));
+    QVERIFY(codecFromProfileName("a2dp-sink").isEmpty());
+    QVERIFY(codecFromProfileName("headset-head-unit").isEmpty());
+    QVERIFY(codecFromProfileName("off").isEmpty());
+
+    // A translated description must not demote SBC-XQ, which is the inversion this fix removes.
+    QVector<ProfileCandidate> translated = {
+        {"a2dp-sink", "Reproduccion de alta fidelidad (A2DP Sink)", 133, true, 1, 0},
+        {"a2dp-sink-sbc_xq", "Reproduccion de alta fidelidad (A2DP Sink)", 131, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(translated), QString("a2dp-sink-sbc_xq"));
+}
+
+QTEST_GUILESS_MAIN(TestProfileChoice)
+#include "tst_profilechoice.moc"


### PR DESCRIPTION
Fixes #27.

Two behaviours:

- An active playback profile is left alone, so a codec the listener chose survives every reconnect. Only `off` and headset profiles trigger a choice.
- When choosing, rank by the codec's bitrate read from the profile description: SBC-XQ 453 > SBC 328 > AAC 256. Names are not codec-stable (AAC is the bare `a2dp-sink` here and `a2dp-sink-aac` does not exist), so the old name list never reached AAC and settled for SBC-XQ while calling it the best available. PipeWire's priority survives only as a tie-break for codecs the table does not know.

The choice moved into `daemon/media/profilechoice.hpp` as pure functions over a PA-free struct, so it is testable without a sound server; the Pulse layer now returns card profiles as data rather than a decision.

Proven on minipc: parked on `headset-head-unit` the daemon picks `a2dp-sink-sbc_xq` and logs `codec SBC-XQ`; parked on `a2dp-sink` it logs `Playback profile already active` and changes nothing. Build rc=0, 0 warnings, ctest 19/19, and the new test reddens under each of: flattening SBC-XQ's bitrate, dropping the priority tie-break, breaking the codec parser, dropping the source exclusion, the sink requirement, or the availability check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Bluetooth audio profile selection by automatically choosing the best available playback profile.
  * Supports codec-aware selection, prioritizing higher-quality audio profiles.
  * Excludes unavailable, input-only, and unsuitable profiles from playback selection.
  * Audio playback remains active when a suitable profile is already enabled.
  * Added clearer profile descriptions to connection logs.
  * Bluetooth profile activation now waits while microphone capture is active and retries automatically when availability is uncertain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->