### PR TITLE
fix: release the card once, and wake on a PulseAudio error

### DIFF
--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -368,11 +368,13 @@ void MediaController::removeAudioOutputDevice() {
     return;
   }
 
+  // Ear detection fires on every packet, so without this the card is re-released every few seconds.
+  if (m_pulseAudio->getActiveCardProfile(m_deviceOutputName) == QStringLiteral("off")) {
+    return;
+  }
+
   LOG_INFO("Removing AirPods as audio output device");
-  // Disable AVRCP volume snap before the sink goes away. Empty
-  // sink-name argument disables the snap path inside
-  // PulseAudioController; safe to call even if it was never
-  // enabled (no-op in that case).
+  // An empty sink name disables the snap, and is safe when it was never enabled.
   m_pulseAudio->enableVolumeSnap(QString(), 5);
   if (!m_pulseAudio->setCardProfile(m_deviceOutputName, "off")) {
     LOG_ERROR("Failed to remove AirPods as audio output device");

--- a/daemon/media/pulseaudiocontroller.cpp
+++ b/daemon/media/pulseaudiocontroller.cpp
@@ -159,7 +159,8 @@ int PulseAudioController::getSinkVolume(const QString &sinkName)
 
     auto callback = [](pa_context *c, const pa_sink_info *info, int eol, void *userdata) {
         CallbackData *d = static_cast<CallbackData*>(userdata);
-        if (eol > 0)
+        // PulseAudio reports a failed query with a negative eol, which must wake the waiter too.
+        if (eol != 0)
         {
             pa_threaded_mainloop_signal(d->mainloop, 0);
             return;
@@ -345,7 +346,8 @@ QString PulseAudioController::getCardNameForDevice(const QString &macAddress)
 
     auto callback = [](pa_context *c, const pa_card_info *info, int eol, void *userdata) {
         CallbackData *d = static_cast<CallbackData*>(userdata);
-        if (eol > 0)
+        // PulseAudio reports a failed query with a negative eol, which must wake the waiter too.
+        if (eol != 0)
         {
             pa_threaded_mainloop_signal(d->mainloop, 0);
             return;
@@ -389,7 +391,8 @@ bool PulseAudioController::isProfileAvailable(const QString &cardName, const QSt
 
     auto callback = [](pa_context *c, const pa_card_info *info, int eol, void *userdata) {
         CallbackData *d = static_cast<CallbackData*>(userdata);
-        if (eol > 0)
+        // PulseAudio reports a failed query with a negative eol, which must wake the waiter too.
+        if (eol != 0)
         {
             pa_threaded_mainloop_signal(d->mainloop, 0);
             return;
@@ -567,7 +570,8 @@ QString PulseAudioController::getActiveCardProfile(const QString &cardName)
 
     auto callback = [](pa_context *, const pa_card_info *info, int eol, void *userdata) {
         CallbackData *d = static_cast<CallbackData*>(userdata);
-        if (eol > 0) {
+        // PulseAudio reports a failed query with a negative eol, which must wake the waiter too.
+        if (eol != 0) {
             pa_threaded_mainloop_signal(d->mainloop, 0);
             return;
         }


### PR DESCRIPTION
Closes #31 and #32.

**#31.** Ear detection calls `removeAudioOutputDevice()` on every packet, so with the pods out of ears the card was re-released and logged 17 times in 20 minutes, each pass also cancelling any pending activation chain. It now returns immediately when the card is already `off`.

Measured on the box with both pods out: 17 releases in 20 minutes before, **1 release in 2 minutes** after, on the transition only.

**#32.** The four remaining query helpers (`getSinkVolume`, `getCardNameForDevice`, `isProfileAvailable`, `getActiveCardProfile`) signalled the mainloop only on `eol > 0`, so a failed introspection left `waitForOperation` waiting out its full 3 second timeout on the Qt main thread instead of returning at once. Every `eol` test in the file now reads `!= 0`, matching `captureState` and `getCardProfiles`.

Build rc=0, 0 warnings, ctest 19/19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated ear-detection events from incorrectly releasing audio devices.
  * Improved handling of failed audio queries so the application does not remain waiting indefinitely.
  * Preserved existing volume cleanup and audio profile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->