### PR TITLE
fix: disable the snap before every early return

### DIFF
--- a/daemon/BluetoothMonitor.cpp
+++ b/daemon/BluetoothMonitor.cpp
@@ -82,13 +82,15 @@ bool BluetoothMonitor::checkAlreadyConnectedDevices()
 
     if (reply.type() == QDBusMessage::ErrorMessage)
     {
-        if (!m_sweepFailureLogged) {
-            LOG_WARN("Failed to get managed objects: " << reply.errorMessage());
-            m_sweepFailureLogged = true;
+        // Keyed on the name as well, since an error reply carrying no string reads empty.
+        const QString sweepError = reply.errorName() + QStringLiteral(": ") + reply.errorMessage();
+        if (sweepError != m_lastSweepError) {
+            LOG_WARN("Failed to get managed objects: " << sweepError);
+            m_lastSweepError = sweepError;
         }
         return false;
     }
-    m_sweepFailureLogged = false;
+    m_lastSweepError.clear();
 
     QVariant firstArg = reply.arguments().constFirst();
     QDBusArgument arg = firstArg.value<QDBusArgument>();

--- a/daemon/BluetoothMonitor.h
+++ b/daemon/BluetoothMonitor.h
@@ -32,8 +32,8 @@ private slots:
 
 private:
     QDBusConnection m_dbus;
-    // The watchdog repeats the sweep, so a permanent failure must not repeat its warning.
-    bool m_sweepFailureLogged = false;
+    // The watchdog repeats the sweep, so only a change of error is worth logging again.
+    QString m_lastSweepError;
     void registerDBusService();
     bool isAirPodsDevice(const QString &devicePath);
     QString getDeviceName(const QString &devicePath);

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -363,6 +363,9 @@ void MediaController::removeAudioOutputDevice() {
   // A retry still in flight would resurrect the sink right after this tears it down.
   cancelPendingA2dpActivation();
 
+  // Disabling the snap needs no device name, so it runs before the guard that can return.
+  m_pulseAudio->enableVolumeSnap(QString(), 5);
+
   if (connectedDeviceMacAddress.isEmpty() || m_deviceOutputName.isEmpty()) {
     LOG_WARN("Connected device MAC address or output name is empty, cannot remove audio output device");
     return;
@@ -374,8 +377,6 @@ void MediaController::removeAudioOutputDevice() {
   }
 
   LOG_INFO("Removing AirPods as audio output device");
-  // An empty sink name disables the snap, and is safe when it was never enabled.
-  m_pulseAudio->enableVolumeSnap(QString(), 5);
   if (!m_pulseAudio->setCardProfile(m_deviceOutputName, "off")) {
     LOG_ERROR("Failed to remove AirPods as audio output device");
   }


### PR DESCRIPTION
Two defects that a review after the merge found in v1.3.3 and v1.3.4.

**The snap teardown sat below two early returns.** `removeAudioOutputDevice()` gained an idempotence guard in v1.3.3 because ear detection calls it on every packet, but `enableVolumeSnap(QString(), 5)` was left below both that guard and the empty-field guard. It needs neither field, so a snap armed by an earlier activation survived both paths. It now runs immediately after the cancel.

**The sweep's failure log deduped on a bool**, so a different failure was swallowed until something succeeded, and the boot-window timeout that v1.3.4 introduced is exactly the issue-24 failure mode. It now keys on `errorName() + errorMessage()`, which also stops an error reply carrying no message string from being silently equal to the no-error sentinel, and the log names the error type rather than an empty string.

Build rc=0, 0 warnings, ctest 19/19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bluetooth connection monitoring now reports distinct sweep failures instead of suppressing repeated or changed errors, while clearing stale errors after recovery.
  * Audio output removal now reliably disables volume snapping, including when device validation ends the operation early.
  * Improved recovery behavior and diagnostic information for Bluetooth and audio device management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->