### PR TITLE
fix: harden the packaged librepods user service

### DIFF
--- a/daemon/librepods.service
+++ b/daemon/librepods.service
@@ -20,9 +20,9 @@ StateDirectoryMode=0700
 ConfigurationDirectory=AirPodsTrayApp
 ConfigurationDirectoryMode=0700
 ProtectSystem=strict
-# /home is its own btrfs subvolume mount here, which strict alone leaves writable.
+# strict leaves /home, /root and /run/user to ProtectHome, so home needs this line.
 ProtectHome=read-only
-# The control socket goes next to the session bus and the PipeWire sockets in the runtime directory.
+# ProtectHome takes /run/user too, and the control socket has to live there.
 ReadWritePaths=%t
 PrivateTmp=yes
 NoNewPrivileges=yes

--- a/daemon/librepods.service
+++ b/daemon/librepods.service
@@ -12,5 +12,31 @@ ExecStart=%h/.local/bin/librepods --headless
 Restart=on-failure
 RestartSec=5
 
+# The status file carries the AirPods identity, so nothing the daemon creates is world-readable.
+UMask=0077
+# systemd creates both at 0700, which is also what makes them writable under ProtectSystem=strict.
+StateDirectory=librepods
+StateDirectoryMode=0700
+ConfigurationDirectory=AirPodsTrayApp
+ConfigurationDirectoryMode=0700
+ProtectSystem=strict
+# The control socket goes next to the session bus and the PipeWire sockets in the runtime directory.
+ReadWritePaths=%t
+PrivateTmp=yes
+NoNewPrivileges=yes
+CapabilityBoundingSet=
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+# BlueZ takes AF_BLUETOOTH, the HCI address-type probe takes AF_NETLINK, everything else is a local socket.
+RestrictAddressFamilies=AF_UNIX AF_BLUETOOTH AF_NETLINK
+
 [Install]
 WantedBy=graphical-session.target

--- a/daemon/librepods.service
+++ b/daemon/librepods.service
@@ -14,12 +14,14 @@ RestartSec=5
 
 # The status file carries the AirPods identity, so nothing the daemon creates is world-readable.
 UMask=0077
-# systemd creates both at 0700, which is also what makes them writable under ProtectSystem=strict.
+# systemd bind-mounts these two writable, which is what carves them out of the read-only home.
 StateDirectory=librepods
 StateDirectoryMode=0700
 ConfigurationDirectory=AirPodsTrayApp
 ConfigurationDirectoryMode=0700
 ProtectSystem=strict
+# /home is its own btrfs subvolume mount here, which strict alone leaves writable.
+ProtectHome=read-only
 # The control socket goes next to the session bus and the PipeWire sockets in the runtime directory.
 ReadWritePaths=%t
 PrivateTmp=yes

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1791,6 +1791,8 @@ public:
             LOG_ERROR("Cannot open state file: " << file.fileName());
             return;
         }
+        // The mode goes on the open temporary the commit renames into place, never on the final path.
+        file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
         file.write(line);
         if (file.commit()) {
             m_lastState = line;
@@ -2026,6 +2028,8 @@ int main(int argc, char *argv[]) {
 
     QLocalServer server;
     QLocalServer::removeServer(ipcPath);
+    // Qt binds the socket at 0777 minus the umask unless told otherwise, and listen() is what applies this.
+    server.setSocketOptions(QLocalServer::UserAccessOption);
 
     if (!server.listen(ipcPath))
     {

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -1792,7 +1792,10 @@ public:
             return;
         }
         // The mode goes on the open temporary the commit renames into place, never on the final path.
-        file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+        if (!file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner)) {
+            LOG_ERROR("Cannot restrict the state file mode, refusing to publish: " << file.fileName());
+            return;
+        }
         file.write(line);
         if (file.commit()) {
             m_lastState = line;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.thisisgm.omapods",
   "name": "AirPods",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": "GM",
   "license": "MIT",
   "description": "AirPods in the Omarchy bar: per-pod and case battery, listening mode, adaptive noise level, conversation awareness, one-bud ANC and ear detection.",


### PR DESCRIPTION
Fixes #37: the shipped unit had no umask, so QSaveFile left status.json at 0644 and Qt bound the control socket at 0755, both carrying the AirPods identity; it now runs under UMask=0077 inside a ProtectSystem=strict plus ProtectHome=read-only sandbox whose only writable paths are the two service directories and the runtime dir, and the daemon sets both modes itself so a manual launch is covered too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved daemon isolation and restricted access to system resources.
  * Strengthened protection for temporary state files and local communication.
  * Limited daemon privileges, capabilities, filesystem access, and network address families.
  * Added dedicated state and configuration storage with safer default permissions.
  * Isolated temporary files and restricted access to sensitive system and home directories.

* **Release**
  * Updated the application version to 1.3.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->