### PR TITLE
fix: duty-cycle the idle BLE scan so bonded devices can reconnect

### DIFF
--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -115,7 +115,7 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
     // whole period past the hold-off it was meant to follow.
     cycleTimer->setTimerType(Qt::PreciseTimer);
     cycleTimer->setInterval(scanBurstMs + scanIdleMs);
-    connect(cycleTimer, &QTimer::timeout, this, &BleManager::beginBurst);
+    connect(cycleTimer, &QTimer::timeout, this, [this]() { beginBurst(true); });
 
     burstTimer = new QTimer(this);
     burstTimer->setSingleShot(true);
@@ -138,7 +138,7 @@ void BleManager::startScan()
     scanRequested = true;
     if (!cycleTimer->isActive())
         cycleTimer->start();
-    beginBurst();
+    beginBurst(false);
 }
 
 void BleManager::stopScan()
@@ -175,25 +175,30 @@ bool BleManager::isScanning() const
 // callers: however often startScan() is invoked, a burst begins at most
 // once per cycle period. lastBurstStartMs gates the stop/start churn of
 // control-link recovery, which would otherwise chain bursts back to back.
-void BleManager::beginBurst()
+void BleManager::beginBurst(bool fromCycleTick)
 {
     if (!scanRequested)
         return;
 
-    // Gate on the idle span, not the whole period: a full-period gate would
-    // reject the very cycle tick it exists to admit, silently halving the
-    // duty cycle if a tick arrives even marginally early.
     const qint64 nowMs = QDeadlineTimer::current().deadline();
     if (nowMs < holdOffUntilMs)
         return; // the cycle clock keeps ticking; the first burst lands after the hold-off
-    if (lastBurstStartMs >= 0 && nowMs - lastBurstStartMs < scanIdleMs)
+
+    // Only caller-initiated starts are gated, and on the full period so a
+    // burst is always followed by scanIdleMs of dark radio. The cycle tick is
+    // exempt: it is already one-per-period, and gating it on elapsed time
+    // makes the duty cycle hostage to timer jitter — a tick arriving a
+    // millisecond early would be dropped and halve the scan rate.
+    if (!fromCycleTick && lastBurstStartMs >= 0
+        && nowMs - lastBurstStartMs < scanBurstMs + scanIdleMs)
         return;
 
-    // Back to the standard cadence after a hold-off re-phased the cycle.
-    if (cycleTimer->interval() != scanBurstMs + scanIdleMs)
-        cycleTimer->setInterval(scanBurstMs + scanIdleMs);
-
     lastBurstStartMs = nowMs;
+    // Re-phase the cycle onto this burst, whichever path started it: the next
+    // tick is then a full period away, and a hold-off's shortened interval is
+    // restored here.
+    cycleTimer->setInterval(scanBurstMs + scanIdleMs);
+    cycleTimer->start();
     discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
     burstTimer->start();
 }

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -8,6 +8,14 @@
 // Fixed header data[0] through data[10], then a 16-byte encrypted payload.
 static constexpr int proximityPairingBytes = 11 + 16;
 
+// AirPods broadcast proximity pairing at roughly 3-10Hz whenever the case
+// lid is open or a pod is out, so an 8-second listen catches them with wide
+// margin. The dark stretch is what matters to the rest of the radio: with
+// the controller out of inquiry ~87% of the time, bonded devices (keyboards,
+// mice) can complete their reconnects instead of queueing behind the scan.
+static constexpr int scanBurstMs = 8000;
+static constexpr int scanIdleMs = 52000;
+
 AirpodsTrayApp::Enums::AirPodsModel getModelName(quint16 modelId)
 {
     using namespace AirpodsTrayApp::Enums;
@@ -99,6 +107,10 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
             this, &BleManager::onScanFinished);
     connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::errorOccurred,
             this, &BleManager::onErrorOccurred);
+
+    dutyCycleTimer = new QTimer(this);
+    dutyCycleTimer->setSingleShot(true);
+    connect(dutyCycleTimer, &QTimer::timeout, this, &BleManager::onDutyCycleTick);
 }
 
 BleManager::~BleManager()
@@ -112,19 +124,48 @@ BleManager::~BleManager()
 
 void BleManager::startScan()
 {
-    LOG_DEBUG("Starting BLE scan...");
+    LOG_DEBUG("Starting BLE scan (duty-cycled)...");
+    scanRequested = true;
+    inBurst = true;
     discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+    dutyCycleTimer->start(scanBurstMs);
 }
 
 void BleManager::stopScan()
 {
     LOG_DEBUG("Stopping BLE scan...");
+    scanRequested = false;
+    inBurst = false;
+    dutyCycleTimer->stop();
     discoveryAgent->stop();
 }
 
+// Callers ask "was scanning supposed to be running", not "is the radio in
+// inquiry this instant" — the recovery paths save this to restore the scan
+// afterwards, and a burst's dark stretch must not read as caller intent to
+// leave the scan off.
 bool BleManager::isScanning() const
 {
-    return discoveryAgent->isActive();
+    return scanRequested;
+}
+
+void BleManager::onDutyCycleTick()
+{
+    if (!scanRequested)
+        return;
+
+    if (inBurst)
+    {
+        inBurst = false;
+        discoveryAgent->stop();
+        dutyCycleTimer->start(scanIdleMs);
+    }
+    else
+    {
+        inBurst = true;
+        discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+        dutyCycleTimer->start(scanBurstMs);
+    }
 }
 
 void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
@@ -228,7 +269,9 @@ void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
 
 void BleManager::onScanFinished()
 {
-    if (discoveryAgent->isActive())
+    // Keep-alive for a burst the stack ended early; the dark stretch of the
+    // duty cycle ends bursts on purpose and must not be undone here.
+    if (scanRequested && inBurst)
     {
         discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
     }

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -2,6 +2,7 @@
 #include "enums.h"
 #include <QDebug>
 #include <QTimer>
+#include <QDeadlineTimer>
 #include "logger.h"
 #include <QMap>
 
@@ -108,9 +109,14 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
     connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::errorOccurred,
             this, &BleManager::onErrorOccurred);
 
-    dutyCycleTimer = new QTimer(this);
-    dutyCycleTimer->setSingleShot(true);
-    connect(dutyCycleTimer, &QTimer::timeout, this, &BleManager::onDutyCycleTick);
+    cycleTimer = new QTimer(this);
+    cycleTimer->setInterval(scanBurstMs + scanIdleMs);
+    connect(cycleTimer, &QTimer::timeout, this, &BleManager::beginBurst);
+
+    burstTimer = new QTimer(this);
+    burstTimer->setSingleShot(true);
+    burstTimer->setInterval(scanBurstMs);
+    connect(burstTimer, &QTimer::timeout, this, [this]() { discoveryAgent->stop(); });
 }
 
 BleManager::~BleManager()
@@ -126,17 +132,25 @@ void BleManager::startScan()
 {
     LOG_DEBUG("Starting BLE scan (duty-cycled)...");
     scanRequested = true;
-    inBurst = true;
-    discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
-    dutyCycleTimer->start(scanBurstMs);
+    if (!cycleTimer->isActive())
+        cycleTimer->start();
+    beginBurst();
 }
 
 void BleManager::stopScan()
 {
     LOG_DEBUG("Stopping BLE scan...");
     scanRequested = false;
-    inBurst = false;
-    dutyCycleTimer->stop();
+    cycleTimer->stop();
+    burstTimer->stop();
+    discoveryAgent->stop();
+}
+
+void BleManager::holdOff(int ms)
+{
+    LOG_DEBUG("Holding BLE scan off for" << ms << "ms so bonded devices can reconnect first");
+    holdOffUntilMs = QDeadlineTimer::current().deadline() + ms;
+    burstTimer->stop();
     discoveryAgent->stop();
 }
 
@@ -149,23 +163,27 @@ bool BleManager::isScanning() const
     return scanRequested;
 }
 
-void BleManager::onDutyCycleTick()
+// The one entrance to inquiry, and the budget lives here, not in the
+// callers: however often startScan() is invoked, a burst begins at most
+// once per cycle period. lastBurstStartMs gates the stop/start churn of
+// control-link recovery, which would otherwise chain bursts back to back.
+void BleManager::beginBurst()
 {
     if (!scanRequested)
         return;
 
-    if (inBurst)
-    {
-        inBurst = false;
-        discoveryAgent->stop();
-        dutyCycleTimer->start(scanIdleMs);
-    }
-    else
-    {
-        inBurst = true;
-        discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
-        dutyCycleTimer->start(scanBurstMs);
-    }
+    // Gate on the idle span rather than the whole period: Qt's coarse
+    // timers run up to 5% early, and a full-period gate would reject the
+    // cycle tick it is meant to admit, silently halving the duty cycle.
+    const qint64 nowMs = QDeadlineTimer::current().deadline();
+    if (nowMs < holdOffUntilMs)
+        return; // the cycle clock keeps ticking; the first burst lands after the hold-off
+    if (lastBurstStartMs >= 0 && nowMs - lastBurstStartMs < scanIdleMs)
+        return;
+
+    lastBurstStartMs = nowMs;
+    discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+    burstTimer->start();
 }
 
 void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
@@ -271,7 +289,7 @@ void BleManager::onScanFinished()
 {
     // Keep-alive for a burst the stack ended early; the dark stretch of the
     // duty cycle ends bursts on purpose and must not be undone here.
-    if (scanRequested && inBurst)
+    if (scanRequested && burstTimer->isActive())
     {
         discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
     }
@@ -279,6 +297,14 @@ void BleManager::onScanFinished()
 
 void BleManager::onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error)
 {
-    LOG_ERROR("BLE scan error occurred:" << error);
-    stopScan();
+    // Transient at boot: the daemon can beat the adapter's power-up and the
+    // first start lands PoweredOffError. Ending only the burst keeps the
+    // caller's intent, so the cycle clock retries on its next period
+    // instead of leaving the scan off until the next restart.
+    LOG_ERROR("BLE scan error occurred:" << error << "- retrying next cycle");
+    burstTimer->stop();
+    discoveryAgent->stop();
+    // The failed start spent no airtime, so it does not count against the
+    // budget — without this the gate would swallow the retry tick too.
+    lastBurstStartMs = -1;
 }

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -110,6 +110,10 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
             this, &BleManager::onErrorOccurred);
 
     cycleTimer = new QTimer(this);
+    // Precise: a coarse timer may fire up to 5% early, and a tick landing
+    // inside a hold-off is rejected — which would push the first burst a
+    // whole period past the hold-off it was meant to follow.
+    cycleTimer->setTimerType(Qt::PreciseTimer);
     cycleTimer->setInterval(scanBurstMs + scanIdleMs);
     connect(cycleTimer, &QTimer::timeout, this, &BleManager::beginBurst);
 
@@ -152,6 +156,10 @@ void BleManager::holdOff(int ms)
     holdOffUntilMs = QDeadlineTimer::current().deadline() + ms;
     burstTimer->stop();
     discoveryAgent->stop();
+    // Re-phase the cycle so its next tick lands at the end of the hold-off
+    // rather than somewhere inside it, for any hold-off length. beginBurst()
+    // restores the standard period once that tick is served.
+    cycleTimer->start(ms);
 }
 
 // Callers ask "was scanning supposed to be running", not "is the radio in
@@ -172,14 +180,18 @@ void BleManager::beginBurst()
     if (!scanRequested)
         return;
 
-    // Gate on the idle span rather than the whole period: Qt's coarse
-    // timers run up to 5% early, and a full-period gate would reject the
-    // cycle tick it is meant to admit, silently halving the duty cycle.
+    // Gate on the idle span, not the whole period: a full-period gate would
+    // reject the very cycle tick it exists to admit, silently halving the
+    // duty cycle if a tick arrives even marginally early.
     const qint64 nowMs = QDeadlineTimer::current().deadline();
     if (nowMs < holdOffUntilMs)
         return; // the cycle clock keeps ticking; the first burst lands after the hold-off
     if (lastBurstStartMs >= 0 && nowMs - lastBurstStartMs < scanIdleMs)
         return;
+
+    // Back to the standard cadence after a hold-off re-phased the cycle.
+    if (cycleTimer->interval() != scanBurstMs + scanIdleMs)
+        cycleTimer->setInterval(scanBurstMs + scanIdleMs);
 
     lastBurstStartMs = nowMs;
     discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
@@ -304,7 +316,9 @@ void BleManager::onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error)
     LOG_ERROR("BLE scan error occurred:" << error << "- retrying next cycle");
     burstTimer->stop();
     discoveryAgent->stop();
-    // The failed start spent no airtime, so it does not count against the
-    // budget — without this the gate would swallow the retry tick too.
-    lastBurstStartMs = -1;
+    // lastBurstStartMs deliberately survives: beginBurst() stamps it before
+    // start(), so the next cycle tick clears the idle gate on its own and
+    // the retry needs no help. Clearing it here would instead let any
+    // startScan() from the recovery ladder start a burst immediately,
+    // reintroducing exactly the rapid churn the gate exists to stop.
 }

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -78,6 +78,7 @@ private slots:
     void onDeviceDiscovered(const QBluetoothDeviceInfo &info);
     void onScanFinished();
     void onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error);
+    void onDutyCycleTick();
 
 signals:
     void deviceFound(const BleInfo &device);
@@ -88,6 +89,17 @@ private:
     // that start/stop/isScan would dereference. Real assignment
     // happens in BleManager::BleManager() via parented `new`.
     QBluetoothDeviceDiscoveryAgent *discoveryAgent = nullptr;
+
+    // A BlueZ discovery session keeps the controller in inquiry, and a
+    // controller stuck in inquiry cannot service the connection
+    // requests of other bonded devices — a keyboard trying to reconnect
+    // at boot waits forever behind a scan that never yields. So the
+    // scan runs in bursts: long enough to catch the AirPods' next
+    // advertisement, dark long enough for everything else on the
+    // radio to get through.
+    QTimer *dutyCycleTimer = nullptr;
+    bool scanRequested = false; // callers' intent, held across bursts
+    bool inBurst = false;
 };
 
 #endif // BLEMANAGER_H

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -74,16 +74,23 @@ public:
     void stopScan();
     bool isScanning() const;
 
+    // Keep the radio dark for `ms` even if a scan is requested. Bonded
+    // devices reconnect in the first seconds after resume and after the
+    // adapter powers up; a burst landing in that window is what leaves a
+    // keyboard dead until Bluetooth is toggled.
+    void holdOff(int ms);
+
 private slots:
     void onDeviceDiscovered(const QBluetoothDeviceInfo &info);
     void onScanFinished();
     void onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error);
-    void onDutyCycleTick();
 
 signals:
     void deviceFound(const BleInfo &device);
 
 private:
+    void beginBurst();
+
     // Default-init so a partial construction (or a refactor that
     // skips the explicit ctor body) doesn't leave a dangling pointer
     // that start/stop/isScan would dereference. Real assignment
@@ -94,12 +101,16 @@ private:
     // controller stuck in inquiry cannot service the connection
     // requests of other bonded devices — a keyboard trying to reconnect
     // at boot waits forever behind a scan that never yields. So the
-    // scan runs in bursts: long enough to catch the AirPods' next
-    // advertisement, dark long enough for everything else on the
-    // radio to get through.
-    QTimer *dutyCycleTimer = nullptr;
-    bool scanRequested = false; // callers' intent, held across bursts
-    bool inBurst = false;
+    // scan runs in bursts on a fixed cycle clock that callers cannot
+    // reset: the control-link recovery ladder legitimately stops and
+    // restarts the scan every few seconds while pods are near but not
+    // connected, and letting each restart begin a fresh burst pinned
+    // the radio in inquiry exactly as if there were no duty cycle.
+    QTimer *cycleTimer = nullptr; // repeating, one burst per period
+    QTimer *burstTimer = nullptr; // single-shot, ends the burst
+    bool scanRequested = false;   // callers' intent, held across bursts
+    qint64 lastBurstStartMs = -1; // CLOCK_MONOTONIC, gates early bursts
+    qint64 holdOffUntilMs = -1;   // CLOCK_MONOTONIC, no bursts before this
 };
 
 #endif // BLEMANAGER_H

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -89,7 +89,10 @@ signals:
     void deviceFound(const BleInfo &device);
 
 private:
-    void beginBurst();
+    // fromCycleTick: the repeating cycle is one-per-period by construction and
+    // needs no elapsed-time gate; caller-initiated starts do, and are held to a
+    // full period since the last burst.
+    void beginBurst(bool fromCycleTick);
 
     // Default-init so a partial construction (or a refactor that
     // skips the explicit ctor body) doesn't leave a dangling pointer

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -55,6 +55,12 @@ using namespace AirpodsTrayApp::Enums;
 // Users filter via QT_LOGGING_RULES with `openpods.*`.
 Q_LOGGING_CATEGORY(openpods, "openpods")
 
+// How long the BLE scan stays dark after resume and after start-up. Bonded
+// devices reconnect within seconds once the adapter is up, but a keyboard
+// woken late by its user still needs a clear radio; a minute covers the
+// gap between "lid opened" and "first key pressed" for nearly everyone.
+static constexpr int reconnectHoldOffMs = 60000;
+
 class AirPodsTrayApp : public QObject {
     Q_OBJECT
     Q_PROPERTY(bool airpodsConnected READ areAirpodsConnected NOTIFY airPodsStatusChanged)
@@ -718,6 +724,9 @@ public slots:
         // don't surface as user-visible "AirPods Disconnected" toasts.
         QTimer::singleShot(2000, this, [this]() {
             // Suspend stopped discovery on every controller, so resume restarts it and the gate below re-applies.
+            // Bonded keyboards and mice reconnect in the first seconds after resume; a scan burst in that
+            // window blocks them until Bluetooth is toggled, so the radio stays dark for a minute first.
+            m_bleManager->holdOff(reconnectHoldOffMs);
             m_bleManager->startScan();
 
             if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
@@ -1595,6 +1604,8 @@ public:
 
         m_deviceInfo->loadFromSettings(*m_settings);
         // Unreachable with the pods already connected: the constructor returns before this.
+        // Same race as resume: at login the adapter is still handing bonded devices their reconnects.
+        m_bleManager->holdOff(reconnectHoldOffMs);
         m_bleManager->startScan();
     }
 


### PR DESCRIPTION
## Summary

`BleManager` opens a continuous BlueZ discovery session and, when AirPods are not connected,
never closes it. While the controller is in inquiry, **other bonded devices cannot complete a
reconnect** — an MX Keys S and a Logi M750 both stayed dead at boot until Bluetooth was toggled.

This is the same root cause as #3 / #26 / #30, but the damage isn't limited to A2DP stutter.
#30 fixed the case where AirPods *are* connected. The remaining hole is the opposite state:
pods in the case — the normal state at a desk — means scanning forever from login onwards.

This keeps the scan but bounds it: 8 s of inquiry per 60 s.

## Reproduction

Omarchy 4.0.1rc1, BlueZ 5.87-2, kernel 7.1.9, Intel 8087:0032, plugin 1.3.5. AirPods in case.

| Daemon | `Discovering` | Result |
|---|---|---|
| running | `yes` | 100 s of keypresses — neither keyboard nor mouse connects |
| stopped | `no` | both connect within 16 s |

Starting the daemon turns discovery on within ~2 s; killing it turns it off. Reproduced three
times, no other variable changed. Recovery otherwise needs `systemctl restart bluetooth`.

## Changes

- **Cycle clock.** A repeating timer admits one 8 s burst per 60 s. The budget lives in
  `BleManager`, not the callers: the control-link recovery ladder calls `stopScan()`/`startScan()`
  every few seconds while pods are near but unconnected, and letting each call start a fresh
  burst pins the radio in inquiry exactly as before. `lastBurstStartMs` gates that churn.
- **`isScanning()` now reports caller intent, not radio state.** `finishControlRecovery()` saves
  and restores it; if it reported live state, a burst's dark stretch would read as "caller wanted
  it off" and the scan would never resume.
- **`onScanFinished()` keep-alive respects the cycle** instead of restarting every finished scan.
- **`onErrorOccurred()` no longer gives up permanently.** At cold boot the daemon can beat the
  adapter's power-up and hit `PoweredOffError`; the old handler called `stopScan()`, killing
  caller intent for the session. It now ends only the burst and retries next cycle.
- **Hold-off after resume and start-up.** `onSystemWakingUp()` restarted the scan 2 s after
  resume — landing a burst exactly where bonded devices make their first reconnect attempt.
  Both paths now `holdOff(60 s)` first.

## Verification

All 19 tests pass. Cadence, hold-off, and cold-adapter retry each confirmed live via
`bluetoothctl show`. Boot behaviour confirmed on the reporting machine (previously intermittent).

## Trade-offs

- Worst-case AirPods discovery latency ~60 s. The 8 s window is generous against a 3–10 Hz
  advertising rate, so it's latency, not loss. `scanBurstMs` / `scanIdleMs` are the knobs — no
  attachment to 8/52.
- `reconnectHoldOffMs = 60 s` is likewise a judgement call.
- The hold-off applies unconditionally, including when pods were connected before suspend.
  Happy to gate it.
- `setLowEnergyDiscoveryTimeout(0)` untouched, to keep the change local to `BleManager`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added duty-cycled Bluetooth scanning to reduce continuous discovery activity.
  * Added a scan holdoff period to temporarily suppress Bluetooth discovery.
* **Bug Fixes**
  * Bluetooth scanning now recovers from discovery errors and retries during the next scan cycle.
  * Scanning remains disabled for 60 seconds after system resume and during startup initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->