### PR TITLE
fix: recover BLE discovery after the adapter goes down

### DIFF
--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -99,6 +99,10 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
             this, &BleManager::onScanFinished);
     connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::errorOccurred,
             this, &BleManager::onErrorOccurred);
+
+    retryTimer = new QTimer(this);
+    retryTimer->setSingleShot(true);
+    connect(retryTimer, &QTimer::timeout, this, &BleManager::retryScan);
 }
 
 BleManager::~BleManager()
@@ -113,22 +117,50 @@ BleManager::~BleManager()
 void BleManager::startScan()
 {
     LOG_DEBUG("Starting BLE scan...");
+    scanWanted = true;
+    retryTimer->stop();
+    noteScanAlive();
     discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
 }
 
 void BleManager::stopScan()
 {
     LOG_DEBUG("Stopping BLE scan...");
+    scanWanted = false;
+    retryTimer->stop();
+    retryLadder.reset();
     discoveryAgent->stop();
 }
 
+// Reports the caller intent, not the radio state, so a scan that waits for a retry still counts as wanted.
 bool BleManager::isScanning() const
 {
-    return discoveryAgent->isActive();
+    return scanWanted;
+}
+
+// Keeps the count that startScan clears, so an adapter that stays down gets a longer delay each time.
+void BleManager::retryScan()
+{
+    if (!scanWanted)
+    {
+        return;
+    }
+
+    LOG_DEBUG("Retrying BLE scan, attempt" << retryLadder.attempts());
+    discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+}
+
+void BleManager::noteScanAlive()
+{
+    retryLadder.reset();
+    lastScanError = QBluetoothDeviceDiscoveryAgent::NoError;
 }
 
 void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
 {
+    // An advertisement proves the radio scans again, so the next failure starts the delay at one second.
+    noteScanAlive();
+
     // Check for Apple's manufacturer ID (0x004C)
     if (info.manufacturerData().contains(0x004C))
     {
@@ -234,8 +266,28 @@ void BleManager::onScanFinished()
     }
 }
 
+// A cold start can begin before the adapter has power, and each connect and disconnect starts the scan again.
+// One failure must not stop discovery for the life of the process.
 void BleManager::onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error)
 {
-    LOG_ERROR("BLE scan error occurred:" << error);
-    stopScan();
+    discoveryAgent->stop();
+
+    if (!scanWanted)
+    {
+        LOG_ERROR("BLE scan error occurred:" << error);
+        return;
+    }
+
+    const int delay = retryLadder.nextDelayMs();
+    // The retry repeats the scan, so only a new error is worth a log line.
+    if (error != lastScanError)
+    {
+        LOG_ERROR("BLE scan error occurred:" << error << ", retrying in" << delay << "ms");
+        lastScanError = error;
+    }
+    else
+    {
+        LOG_DEBUG("BLE scan error repeated:" << error << ", retrying in" << delay << "ms");
+    }
+    retryTimer->start(delay);
 }

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -103,6 +103,10 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
     retryTimer = new QTimer(this);
     retryTimer->setSingleShot(true);
     connect(retryTimer, &QTimer::timeout, this, &BleManager::retryScan);
+
+    localDevice = new QBluetoothLocalDevice(this);
+    connect(localDevice, &QBluetoothLocalDevice::hostModeStateChanged,
+            this, &BleManager::onHostModeChanged);
 }
 
 BleManager::~BleManager()
@@ -148,6 +152,21 @@ void BleManager::retryScan()
 
     LOG_DEBUG("Retrying BLE scan, attempt" << retryLadder.attempts());
     discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+}
+
+// The agent gets no signal when the adapter drops a live scan, and it still reports that scan as active.
+// The host mode change is the only event left, so use it to start the scan again.
+void BleManager::onHostModeChanged(QBluetoothLocalDevice::HostMode mode)
+{
+    if (mode == QBluetoothLocalDevice::HostPoweredOff || !scanWanted)
+    {
+        return;
+    }
+
+    LOG_INFO("Bluetooth adapter powered on, restarting the BLE scan");
+    // Call stop() first, because start() does nothing while the agent still reports an active scan.
+    discoveryAgent->stop();
+    startScan();
 }
 
 void BleManager::noteScanAlive()

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QBluetoothDeviceDiscoveryAgent>
+#include <QBluetoothLocalDevice>
 #include <QMap>
 #include <QString>
 #include <QDateTime>
@@ -79,6 +80,7 @@ private slots:
     void onDeviceDiscovered(const QBluetoothDeviceInfo &info);
     void onScanFinished();
     void onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error);
+    void onHostModeChanged(QBluetoothLocalDevice::HostMode mode);
     void retryScan();
 
 signals:
@@ -93,6 +95,7 @@ private:
     // happens in BleManager::BleManager() via parented `new`.
     QBluetoothDeviceDiscoveryAgent *discoveryAgent = nullptr;
     QTimer *retryTimer = nullptr;
+    QBluetoothLocalDevice *localDevice = nullptr;
     BleScanRetry::Ladder retryLadder;
     // What the caller asked for, not what the radio does. A scan that waits for a retry stays wanted.
     bool scanWanted = false;

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -6,6 +6,7 @@
 #include <QMap>
 #include <QString>
 #include <QDateTime>
+#include "blescanretry.hpp"
 #include "enums.h"
 
 class QTimer;
@@ -78,16 +79,24 @@ private slots:
     void onDeviceDiscovered(const QBluetoothDeviceInfo &info);
     void onScanFinished();
     void onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error);
+    void retryScan();
 
 signals:
     void deviceFound(const BleInfo &device);
 
 private:
+    void noteScanAlive();
+
     // Default-init so a partial construction (or a refactor that
     // skips the explicit ctor body) doesn't leave a dangling pointer
     // that start/stop/isScan would dereference. Real assignment
     // happens in BleManager::BleManager() via parented `new`.
     QBluetoothDeviceDiscoveryAgent *discoveryAgent = nullptr;
+    QTimer *retryTimer = nullptr;
+    BleScanRetry::Ladder retryLadder;
+    // What the caller asked for, not what the radio does. A scan that waits for a retry stays wanted.
+    bool scanWanted = false;
+    QBluetoothDeviceDiscoveryAgent::Error lastScanError = QBluetoothDeviceDiscoveryAgent::NoError;
 };
 
 #endif // BLEMANAGER_H

--- a/daemon/ble/blescanretry.hpp
+++ b/daemon/ble/blescanretry.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <algorithm>
+
+namespace BleScanRetry
+{
+// The delay doubles from one second, with a limit of 32 seconds.
+inline constexpr int baseDelayMs = 1000;
+inline constexpr int maxDoublings = 6;
+
+inline int delayMs(int attempt)
+{
+    const int boundedAttempt = std::clamp(attempt, 1, maxDoublings);
+    return baseDelayMs * (1 << (boundedAttempt - 1));
+}
+
+// One counter for the process. A reset gives the next failure the short delay again.
+class Ladder
+{
+public:
+    int nextDelayMs() { return delayMs(++m_attempts); }
+    void reset() { m_attempts = 0; }
+    int attempts() const { return m_attempts; }
+
+private:
+    int m_attempts = 0;
+};
+}

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -150,6 +150,7 @@ openpods_add_test(tst_blemanager
     tst_blemanager.cpp
     ../ble/blemanager.cpp
     ../ble/blemanager.h
+    ../ble/blescanretry.hpp
 )
 # Only test that parses a QBluetoothDeviceInfo, so only one needing the module.
 target_link_libraries(tst_blemanager PRIVATE Qt6::Bluetooth)

--- a/daemon/tests/tst_blemanager.cpp
+++ b/daemon/tests/tst_blemanager.cpp
@@ -1,8 +1,11 @@
 #include <QtTest>
 #include <QBluetoothAddress>
+#include <QBluetoothDeviceDiscoveryAgent>
 #include <QBluetoothDeviceInfo>
+#include <QTimer>
 
 #include "../ble/blemanager.h"
+#include "../ble/blescanretry.hpp"
 
 // main.cpp defines the Q_LOGGING_CATEGORY symbol, but tests don't link main.cpp.
 Q_LOGGING_CATEGORY(openpods, "openpods.test", QtWarningMsg)
@@ -61,6 +64,28 @@ static int parseFrame(const QByteArray &frame, BleInfo *emitted)
     return emissions;
 }
 
+// PoweredOffError is the error a cold start sees when the daemon starts before the adapter.
+static void failScan(BleManager &manager)
+{
+    QMetaObject::invokeMethod(&manager, "onErrorOccurred", Qt::DirectConnection,
+                              Q_ARG(QBluetoothDeviceDiscoveryAgent::Error,
+                                    QBluetoothDeviceDiscoveryAgent::PoweredOffError));
+}
+
+// start() can fail at once on a box with no adapter, so reset the count with an advertisement first.
+static void seeAdvertisement(BleManager &manager)
+{
+    QMetaObject::invokeMethod(&manager, "onDeviceDiscovered", Qt::DirectConnection,
+                              Q_ARG(QBluetoothDeviceInfo,
+                                    advertisement(QByteArray::fromHex(airPodsFrameHex))));
+}
+
+// discoveryAgent is the only other direct child, and it is not a QTimer.
+static QTimer *retryTimerOf(BleManager &manager)
+{
+    return manager.findChild<QTimer *>(QString(), Qt::FindDirectChildrenOnly);
+}
+
 class TestBleManager : public QObject
 {
     Q_OBJECT
@@ -70,6 +95,10 @@ private slots:
     void unparseableFrameIsDropped();
     void realAirPodsFrameIsParsed();
     void podsBatteryKeepsLeftAndRightApart();
+    void retryDelayDoublesAndCaps();
+    void scanErrorArmsARetryAndKeepsTheIntent();
+    void advertisementResetsTheRetryLadder();
+    void stoppedScanIsNotRestartedByAFailure();
 };
 
 void TestBleManager::unparseableFrameIsDropped_data()
@@ -116,6 +145,85 @@ void TestBleManager::podsBatteryKeepsLeftAndRightApart()
     QCOMPARE(parseFrame(withRightPodPrimary(unequalPods), &parsed), 1);
     QCOMPARE(parsed.leftPodBattery, 80);
     QCOMPARE(parsed.rightPodBattery, 20);
+}
+
+void TestBleManager::retryDelayDoublesAndCaps()
+{
+    QCOMPARE(BleScanRetry::delayMs(1), 1000);
+    QCOMPARE(BleScanRetry::delayMs(2), 2000);
+    QCOMPARE(BleScanRetry::delayMs(BleScanRetry::maxDoublings), 32000);
+    QCOMPARE(BleScanRetry::delayMs(BleScanRetry::maxDoublings + 5), 32000);
+    // An attempt of zero still gets the first delay.
+    QCOMPARE(BleScanRetry::delayMs(0), 1000);
+
+    BleScanRetry::Ladder ladder;
+    QCOMPARE(ladder.nextDelayMs(), 1000);
+    QCOMPARE(ladder.nextDelayMs(), 2000);
+    QCOMPARE(ladder.attempts(), 2);
+    ladder.reset();
+    QCOMPARE(ladder.nextDelayMs(), 1000);
+}
+
+// The cold start in issue 24. The adapter is down, the scan fails, and nothing starts it again.
+void TestBleManager::scanErrorArmsARetryAndKeepsTheIntent()
+{
+    BleManager manager;
+
+    manager.startScan();
+    seeAdvertisement(manager);
+    failScan(manager);
+
+    // The defect. One error stopped the scan for the life of the process.
+    QVERIFY(manager.isScanning());
+
+    QTimer *retry = retryTimerOf(manager);
+    QVERIFY(retry);
+    QVERIFY(retry->isActive());
+    QCOMPARE(retry->interval(), BleScanRetry::delayMs(1));
+
+    manager.stopScan();
+}
+
+// Each connect and disconnect starts the scan again, so a new failure must not keep the old delay.
+void TestBleManager::advertisementResetsTheRetryLadder()
+{
+    BleManager manager;
+    QTimer *retry = retryTimerOf(manager);
+    QVERIFY(retry);
+
+    manager.startScan();
+    seeAdvertisement(manager);
+    failScan(manager);
+    failScan(manager);
+    QCOMPARE(retry->interval(), BleScanRetry::delayMs(2));
+
+    seeAdvertisement(manager);
+    failScan(manager);
+    QCOMPARE(retry->interval(), BleScanRetry::delayMs(1));
+
+    manager.stopScan();
+}
+
+// The connected gate and the sleep gate stop the scan on purpose. A retry must not undo that.
+void TestBleManager::stoppedScanIsNotRestartedByAFailure()
+{
+    BleManager manager;
+    QTimer *retry = retryTimerOf(manager);
+    QVERIFY(retry);
+
+    manager.startScan();
+    QVERIFY(manager.isScanning());
+    seeAdvertisement(manager);
+    failScan(manager);
+    QVERIFY(retry->isActive());
+
+    manager.stopScan();
+    QVERIFY(!retry->isActive());
+    QVERIFY(!manager.isScanning());
+
+    failScan(manager);
+    QVERIFY(!retry->isActive());
+    QVERIFY(!manager.isScanning());
 }
 
 QTEST_GUILESS_MAIN(TestBleManager)

--- a/daemon/tests/tst_blemanager.cpp
+++ b/daemon/tests/tst_blemanager.cpp
@@ -2,6 +2,7 @@
 #include <QBluetoothAddress>
 #include <QBluetoothDeviceDiscoveryAgent>
 #include <QBluetoothDeviceInfo>
+#include <QBluetoothLocalDevice>
 #include <QTimer>
 
 #include "../ble/blemanager.h"
@@ -80,7 +81,15 @@ static void seeAdvertisement(BleManager &manager)
                                     advertisement(QByteArray::fromHex(airPodsFrameHex))));
 }
 
-// discoveryAgent is the only other direct child, and it is not a QTimer.
+// HostConnectable is the mode BlueZ reports after the adapter has power again.
+static void powerAdapterOn(BleManager &manager)
+{
+    QMetaObject::invokeMethod(&manager, "onHostModeChanged", Qt::DirectConnection,
+                              Q_ARG(QBluetoothLocalDevice::HostMode,
+                                    QBluetoothLocalDevice::HostConnectable));
+}
+
+// discoveryAgent and localDevice are the only other direct children, and neither is a QTimer.
 static QTimer *retryTimerOf(BleManager &manager)
 {
     return manager.findChild<QTimer *>(QString(), Qt::FindDirectChildrenOnly);
@@ -99,6 +108,7 @@ private slots:
     void scanErrorArmsARetryAndKeepsTheIntent();
     void advertisementResetsTheRetryLadder();
     void stoppedScanIsNotRestartedByAFailure();
+    void adapterPowerOnRestartsAWantedScan();
 };
 
 void TestBleManager::unparseableFrameIsDropped_data()
@@ -223,6 +233,27 @@ void TestBleManager::stoppedScanIsNotRestartedByAFailure()
 
     failScan(manager);
     QVERIFY(!retry->isActive());
+    QVERIFY(!manager.isScanning());
+}
+
+// The adapter drops a live scan with no signal, so the power state must start it again.
+void TestBleManager::adapterPowerOnRestartsAWantedScan()
+{
+    BleManager manager;
+    QTimer *retry = retryTimerOf(manager);
+    QVERIFY(retry);
+
+    manager.startScan();
+    seeAdvertisement(manager);
+    failScan(manager);
+    QVERIFY(retry->isActive());
+
+    powerAdapterOn(manager);
+    QVERIFY(manager.isScanning());
+    QVERIFY(!retry->isActive());
+
+    manager.stopScan();
+    powerAdapterOn(manager);
     QVERIFY(!manager.isScanning());
 }
 


### PR DESCRIPTION
This is the BLE half of #24, sent as its own pull request as you asked in [this comment](https://github.com/thisisgm/omarchy-pods/issues/24#issuecomment-5387260317). It also covers the point you added [here](https://github.com/thisisgm/omarchy-pods/issues/24#issuecomment-5388403165), because that turned out to be a second defect and not the same one.

## Two defects, not one

**1. A failed scan start ends discovery for the life of the process.** `BleManager::onErrorOccurred` logs the error and calls `stopScan()`. A daemon that starts before the adapter has power gets `PoweredOffError` and never scans again. This is the one described in #24.

**2. A live scan dies with no signal at all.** When the adapter loses power under a running scan, Qt sends no `errorOccurred`, no `finished` and no `canceled`. `QBluetoothDeviceDiscoveryAgent::isActive()` keeps returning `true` while BlueZ reports `Discovering: no`. An error handler cannot see this, so the retry in the first commit does not fix it.

Defect 2 is the one you named in the fold-in comment. #30 stops and starts the scan on each connect and disconnect cycle, so the scan now crosses the adapter power state far more often than it used to.

I found defect 2 with temporary instrumentation on a branch build. The probe logged `canceled`, `finished`, and the agent state every 3 s. The adapter went down at t=9s and came back at t=10s:

```
openpods:  Starting BLE scan...
openpods:  PROBE isActive= true  wanted= true
openpods:  PROBE isActive= true  wanted= true     <- adapter is off here
openpods:  PROBE isActive= true  wanted= true
...                                                 23 ticks, no other line
```

No signal arrived, and `isActive()` stayed `true` for the whole run while `bluetoothctl show` reported `Discovering: no`. The probe is not in this diff.

## The fix

Two commits, one for each defect.

`248da8e` replaces the `stopScan()` in the error handler with a backoff ladder. The delay doubles from 1 s and stops at 32 s. `isScanning()` now reports what the caller asked for and not what the radio does, so a scan that waits for a retry still counts as wanted. `stopScan()` cancels a pending retry, so the connected gate, the sleep gate and the control recovery keep the decision to stop. An advertisement resets the ladder, so a later transient failure waits one second and not half a minute.

`1334eeb` connects `QBluetoothLocalDevice::hostModeStateChanged`. When the adapter has power again and the caller still wants a scan, the daemon stops the agent and starts it again. The `stop()` is needed because `start()` does nothing while the agent still reports an active scan.

## Reproduction

No AirPods are needed to watch discovery die. `bluetoothctl show` reports `Discovering`, and that is the state that decides whether the panel can ever fill.

```bash
systemctl --user stop librepods.service
bluetoothctl power off
QT_FORCE_STDERR_LOGGING=1 librepods --headless &
sleep 5
bluetoothctl power on
# then sample: bluetoothctl show | awk '/Discovering:/{print $2}'
```

Cold start, adapter down at daemon start, power on at t=5s:

| build | Discovering, 60 s after the adapter returned |
| --- | --- |
| v1.3.6 (`fff7fec`) | `no` for the whole window |
| this branch | `yes` within 5 s |

Live scan, adapter power off at t=5s and on at t=10s:

| build | Discovering, 60 s after the adapter returned |
| --- | --- |
| v1.3.6 (`fff7fec`) | `no` for the whole window |
| this branch | `yes` within 5 s |

The log for the cold start on this branch shows both mechanisms in one run:

```
openpods:  Starting BLE scan...
openpods:  BLE scan error occurred: QBluetoothDeviceDiscoveryAgent::PoweredOffError , retrying in 1000 ms
openpods:  Retrying BLE scan, attempt 1
openpods:  BLE scan error repeated: QBluetoothDeviceDiscoveryAgent::PoweredOffError , retrying in 2000 ms
openpods:  Retrying BLE scan, attempt 2
openpods:  BLE scan error repeated: QBluetoothDeviceDiscoveryAgent::PoweredOffError , retrying in 4000 ms
openpods:  Bluetooth adapter powered on, restarting the BLE scan
openpods:  Starting BLE scan...
```

Stock logs one line and stops:

```
openpods:  Starting BLE scan...
openpods:  BLE scan error occurred: QBluetoothDeviceDiscoveryAgent::PoweredOffError
openpods:  Stopping BLE scan...
```

## The panel, with the pods in the case

Same cold start, with the AirPods in the case beside the machine. `XDG_STATE_HOME` was redirected, so this did not touch the real panel state.

Stock `fff7fec`:

```
t=10  discovering=no  connected=False left=- right=- case=- lid=2
t=20  discovering=no  connected=False left=- right=- case=- lid=2
t=40  discovering=no  connected=False left=- right=- case=- lid=2
```

This branch:

```
t=10  discovering=yes  connected=False left=- right=- case=- lid=2
t=20  discovering=yes  connected=False left=100 right=100 case=90 lid=0
t=40  discovering=yes  connected=False left=100 right=100 case=90 lid=2
```

The daemon log for that run, next to the state above:

```
openpods:  BLE scan error occurred: QBluetoothDeviceDiscoveryAgent::PoweredOffError , retrying in 1000 ms
openpods:  Retrying BLE scan, attempt 1
openpods:  BLE scan error repeated: QBluetoothDeviceDiscoveryAgent::PoweredOffError , retrying in 2000 ms
openpods:  Retrying BLE scan, attempt 2
openpods:  BLE scan error repeated: QBluetoothDeviceDiscoveryAgent::PoweredOffError , retrying in 4000 ms
openpods:  Bluetooth adapter powered on, restarting the BLE scan
openpods:  Starting BLE scan...
openpods:  BLE adv accepted caseBattery= 90  charge= false  primaryLeft= true
openpods:  BLE adv accepted caseBattery= 90  charge= false  primaryLeft= false
```

`status.json` from a second run of the same scenario, sampled while the lid was open:

```json
{
  "case": { "available": true, "charging": false, "level": 90 },
  "connected": false,
  "device_name": "AirPods Pro",
  "left": { "available": true, "charging": true, "in_ear": false, "level": 100 },
  "lid_state": 0,
  "model_name": "AirPods Pro 2",
  "right": { "available": true, "charging": true, "in_ear": false, "level": 100 }
}
```

Machine: Omarchy on Arch Linux, kernel 7.1.9, BlueZ 5.87, Qt 6.11.2, Realtek adapter (TP-Link USB 2357:0604) on hci0, AirPods Pro 2 (A2698). Plugin 1.3.6.

## What I ran

- `cmake -B build -G Ninja && cmake --build build && ctest --test-dir build`: 19 of 19 pass on each commit.
- Red first, for each commit:
  - Keep the tests and `blescanretry.hpp`, revert `blemanager.cpp` and `blemanager.h` to `fff7fec`: `FAIL!  : TestBleManager::scanErrorArmsARetryAndKeepsTheIntent() 'manager.isScanning()' returned FALSE.` and two more.
  - Keep the tests, revert both files to `248da8e`: `FAIL!  : TestBleManager::adapterPowerOnRestartsAWantedScan() '!retry->isActive()' returned FALSE.`
- The four measurements above, on the box.

## What I assumed, so you can check it in one grep

- **`isScanning()` has three callers, and all three want caller intent.** `stopBleScanWhileConnected()` and `onSystemGoingToSleep()` use it to decide whether to call `stopScan()`, and a scan that waits for a retry must answer yes there or the retry outlives the gate. `scheduleControlReconnect()` saves it and `finishControlRecovery()` restores it, and intent is the right thing to restore.
- **An adapter power change is the only trigger I can drive.** An adapter that wedges without a power state change is not covered by either commit.
- **I did not touch `onScanFinished()`.** Its `if (discoveryAgent->isActive())` cannot be true inside a `finished` handler, so the keep-alive there is already dead. It is a separate question and not this diff.
- **The pods were never connected during these runs.** I did not drive a suspend and resume cycle.

## Trade-offs

- Worst case latency after the adapter returns is 32 s, if the host mode change never arrives and only the ladder recovers. In every run here the host mode change arrived and recovery took under 5 s.
- `hostModeStateChanged` also fires on a change between `HostConnectable` and `HostDiscoverable`. The scan then stops and starts once. That costs a short gap in discovery, and it cannot happen while the pods are connected, because the gate has already set the intent to off.
- The first failure logs at error level and repeats log at debug level, so a permanently blocked adapter writes one line and not two a minute.

## Overlap with #39

#39 also rewrites `onErrorOccurred` and also moves `isScanning()` to caller intent, inside a larger duty cycle change. The two pull requests will conflict. This one is only the #24 recovery you asked for, and it does not change the scan cadence. I am happy to rebase onto #39 if that lands first, or to close this if you would rather take the whole thing there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BLE scanning now automatically retries after errors, using progressively longer delays.
  * Scanning resumes when Bluetooth is powered back on, if scanning was requested.
  * Successful device discovery resets retry delays for faster recovery.

* **Bug Fixes**
  * Scan requests remain active through temporary Bluetooth errors instead of stopping permanently.

* **Tests**
  * Added coverage for retry delays, scan recovery, Bluetooth power changes, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->