### PR TITLE
feat: let the listener pin the playback codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ which is SBC-XQ at 453 kbps ahead of SBC at 328 and AAC at 256. That is the
 default, and it is re-applied every time the daemon activates the card, because
 PipeWire's own profile priority puts AAC first and would otherwise win.
 
+Bitrate is not the whole story, and on AirPods it can be the wrong story. AAC is what the
+hardware decodes natively and what macOS sends, and SBC-XQ at a higher bitrate is not
+automatically the better of the two. If SBC-XQ sounds thin to you, name the codec you want
+under `[audio]` in `~/.config/AirPodsTrayApp/AirPodsTrayApp.conf`:
+
+```ini
+[audio]
+preferredCodec=AAC
+```
+
+Any codec the card lists as a playback profile, matched case-insensitively, so `AAC`,
+`SBC-XQ` or `SBC` here. Restart the daemon to apply it. The named codec wins on every
+connect, cold ones included. Leave it unset, or name one the card does not offer, and the
+bitrate ranking above stands; an unmet preference is logged with the codec that could not
+be honoured. A profile that is already active is still left alone, so changing the codec by
+hand with `pactl set-card-profile` keeps working.
+
 Selecting the AirPods as a **microphone** gives that up. Over the standard
 Bluetooth profiles, two-way voice runs on a separate low-bandwidth channel, so
 the only profiles exposing a source are `headset-head-unit` at 16 kHz mSBC and

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -108,6 +108,7 @@ public:
 
         // Initialize MediaController and connect signals
         mediaController = new MediaController(this);
+        mediaController->setPreferredCodec(loadPreferredCodec());
         connect(mediaController, &MediaController::mediaStateChanged, this, &AirPodsTrayApp::handleMediaStateChange);
         mediaController->followMediaChanges();
 
@@ -679,6 +680,9 @@ public slots:
 
     int loadEarDetectionSettings() { return m_settings->value("earDetection/setting", MediaController::EarDetectionBehavior::PauseWhenOneRemoved).toInt(); }
     void saveEarDetectionSettings() { m_settings->setValue("earDetection/setting", mediaController->getEarDetectionBehavior()); }
+
+    // Empty is the default: the bitrate ranking in profilechoice.hpp stands unless a codec is named.
+    QString loadPreferredCodec() const { return m_settings->value("audio/preferredCodec", QString()).toString(); }
 
     bool loadNotificationsEnabled() const { return m_settings->value("notifications/enabled", true).toBool(); }
     void saveNotificationsEnabled(bool enabled) { m_settings->setValue("notifications/enabled", enabled); }

--- a/daemon/media/mediacontroller.cpp
+++ b/daemon/media/mediacontroller.cpp
@@ -201,6 +201,15 @@ void MediaController::handleConversationalAwareness(const QByteArray &data) {
 }
 
 
+// A new preference has to outrank the cached pick, or it lands only after the next card change.
+void MediaController::setPreferredCodec(const QString &codec) {
+  if (m_preferredCodec == codec) {
+    return;
+  }
+  m_preferredCodec = codec;
+  m_cachedA2dpProfile.clear();
+}
+
 // Available when the card offers any playback profile at all.
 bool MediaController::isA2dpProfileAvailable() {
   return !getPreferredA2dpProfile().isEmpty();
@@ -217,7 +226,11 @@ QString MediaController::getPreferredA2dpProfile() {
   }
 
   const QVector<ProfileCandidate> profiles = m_pulseAudio->getCardProfiles(m_deviceOutputName);
-  m_cachedA2dpProfile = bestPlaybackProfile(profiles);
+  m_cachedA2dpProfile = bestPlaybackProfile(profiles, m_preferredCodec);
+  if (!m_preferredCodec.isEmpty() && preferredPlaybackProfile(profiles, m_preferredCodec).isEmpty()) {
+    LOG_WARN("Card " << m_deviceOutputName << " offers no playback profile for preferredCodec "
+             << m_preferredCodec << ", falling back to the highest bitrate it does offer");
+  }
   if (!m_cachedA2dpProfile.isEmpty()) {
     // The profile name hides the codec: AAC is the bare `a2dp-sink` on this stack.
     LOG_INFO("Selected best available output profile: " << m_cachedA2dpProfile

--- a/daemon/media/mediacontroller.h
+++ b/daemon/media/mediacontroller.h
@@ -40,6 +40,9 @@ public:
   void removeAudioOutputDevice();
   void setConnectedDeviceMacAddress(const QString &macAddress);
   bool isA2dpProfileAvailable();
+
+  // Empty keeps the bitrate ranking; a codec name ("AAC", "SBC-XQ", "SBC") pins that profile.
+  void setPreferredCodec(const QString &codec);
   QString getPreferredA2dpProfile();
   QString getActiveProfile();
   bool restartWirePlumber();
@@ -70,6 +73,7 @@ private:
   PlayerStatusWatcher *playerStatusWatcher = nullptr;
   PulseAudioController *m_pulseAudio = nullptr;
   QString m_cachedA2dpProfile;
+  QString m_preferredCodec;
   quint64 m_earDetectionGeneration = 0;
   bool m_earOutPending = false;
   // A queued retry compares its captured generation against this, so a superseded chain stops.

--- a/daemon/media/profilechoice.hpp
+++ b/daemon/media/profilechoice.hpp
@@ -61,21 +61,52 @@ inline QString profileDescription(const QVector<ProfileCandidate> &candidates, c
     return QString();
 }
 
-// A profile carrying a source is the headset mic path, never the playback one.
-inline QString bestPlaybackProfile(const QVector<ProfileCandidate> &candidates)
+// A playback profile is one that carries a sink and no source; a source means the headset mic path.
+inline bool isPlaybackCandidate(const ProfileCandidate &c)
 {
+    return c.available && c.sinks > 0 && c.sources == 0;
+}
+
+// The name survives a translated locale, so it is tried first and the description backs it up.
+inline QString codecOf(const ProfileCandidate &c)
+{
+    const QString fromName = codecFromProfileName(c.name);
+    return codecBitrateKbps(fromName) > 0 ? fromName : codecFromDescription(c.description);
+}
+
+// Empty means no preference, which leaves bestPlaybackProfile's ranking in charge.
+inline QString preferredPlaybackProfile(const QVector<ProfileCandidate> &candidates,
+                                        const QString &preferredCodec)
+{
+    if (preferredCodec.isEmpty()) {
+        return QString();
+    }
+    for (const ProfileCandidate &c : candidates) {
+        if (isPlaybackCandidate(c) && codecOf(c).compare(preferredCodec, Qt::CaseInsensitive) == 0) {
+            return c.name;
+        }
+    }
+    // Empty lets the caller fall back to the ranking, and log which codec it could not honour.
+    return QString();
+}
+
+// A profile carrying a source is the headset mic path, never the playback one.
+inline QString bestPlaybackProfile(const QVector<ProfileCandidate> &candidates,
+                                   const QString &preferredCodec = QString())
+{
+    const QString preferred = preferredPlaybackProfile(candidates, preferredCodec);
+    if (!preferred.isEmpty()) {
+        return preferred;
+    }
+
     QString best;
     int bestBitrate = -1;
     int bestPriority = -1;
     for (const ProfileCandidate &c : candidates) {
-        if (!c.available || c.sinks == 0 || c.sources > 0) {
+        if (!isPlaybackCandidate(c)) {
             continue;
         }
-        // The name survives a translated locale, so it is tried first and the description backs it up.
-        int bitrate = codecBitrateKbps(codecFromProfileName(c.name));
-        if (bitrate == 0) {
-            bitrate = codecBitrateKbps(codecFromDescription(c.description));
-        }
+        int bitrate = codecBitrateKbps(codecOf(c));
         if (bitrate > bestBitrate || (bitrate == bestBitrate && c.priority > bestPriority)) {
             bestBitrate = bitrate;
             bestPriority = c.priority;

--- a/daemon/tests/tst_profilechoice.cpp
+++ b/daemon/tests/tst_profilechoice.cpp
@@ -16,6 +16,11 @@ private slots:
     void returnsEmptyWhenNothingQualifies();
     void readsTheCodecOutOfAProfileDescription();
     void readsTheCodecOutOfTheProfileNameToo();
+    void aPreferredCodecOutranksTheBitrateWinner();
+    void aPreferredCodecIsMatchedCaseInsensitively();
+    void anUnmatchedPreferredCodecFallsBackToTheRanking();
+    void aPreferredCodecNeverReachesAHeadsetOrDeadProfile();
+    void aPreferredCodecTheRankingCannotReachIsStillHonoured();
 };
 
 static QVector<ProfileCandidate> airPodsCard()
@@ -153,6 +158,63 @@ void TestProfileChoice::readsTheCodecOutOfTheProfileNameToo()
         {"a2dp-sink-sbc_xq", "Reproduccion de alta fidelidad (A2DP Sink)", 131, true, 1, 0},
     };
     QCOMPARE(bestPlaybackProfile(translated), QString("a2dp-sink-sbc_xq"));
+}
+
+void TestProfileChoice::aPreferredCodecOutranksTheBitrateWinner()
+{
+    // Naming AAC has to beat the ranking's SBC-XQ, or the setting only confirms its own pick.
+    QCOMPARE(bestPlaybackProfile(airPodsCard()), QString("a2dp-sink-sbc_xq"));
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "AAC"), QString("a2dp-sink"));
+
+    // And the other direction, so the test cannot pass by always returning the AAC row.
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "SBC"), QString("a2dp-sink-sbc"));
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "SBC-XQ"), QString("a2dp-sink-sbc_xq"));
+}
+
+void TestProfileChoice::aPreferredCodecIsMatchedCaseInsensitively()
+{
+    // The value comes from a hand-edited settings file, so case is not the user's problem.
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "aac"), QString("a2dp-sink"));
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "sbc-xq"), QString("a2dp-sink-sbc_xq"));
+}
+
+void TestProfileChoice::anUnmatchedPreferredCodecFallsBackToTheRanking()
+{
+    // A typo, or a codec this card does not offer, must not silence playback.
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "LDAC"), QString("a2dp-sink-sbc_xq"));
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "AAAC"), QString("a2dp-sink-sbc_xq"));
+
+    // An empty preference is the default and must leave the ranking untouched.
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), QString()), QString("a2dp-sink-sbc_xq"));
+}
+
+void TestProfileChoice::aPreferredCodecNeverReachesAHeadsetOrDeadProfile()
+{
+    // MSBC exists here only on a profile carrying a source, so naming it must not reach it.
+    QCOMPARE(bestPlaybackProfile(airPodsCard(), "MSBC"), QString("a2dp-sink-sbc_xq"));
+
+    // An unavailable profile is not selectable however explicitly it is named.
+    QVector<ProfileCandidate> aacUnavailable = {
+        {"a2dp-sink", "High Fidelity Playback (A2DP Sink, codec AAC)", 133, false, 1, 0},
+        {"a2dp-sink-sbc", "High Fidelity Playback (A2DP Sink, codec SBC)", 132, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(aacUnavailable, "AAC"), QString("a2dp-sink-sbc"));
+}
+
+void TestProfileChoice::aPreferredCodecTheRankingCannotReachIsStillHonoured()
+{
+    // The ranking scores an unknown codec zero and can never pick it, so naming it is the only way.
+    QVector<ProfileCandidate> ldacCard = {
+        {"a2dp-sink-sbc_xq", "High Fidelity Playback (A2DP Sink, codec SBC-XQ)", 131, true, 1, 0},
+        {"a2dp-sink-ldac", "High Fidelity Playback (A2DP Sink, codec LDAC)", 140, true, 1, 0},
+        {"a2dp-sink", "High Fidelity Playback (A2DP Sink, codec AAC)", 133, true, 1, 0},
+    };
+    QCOMPARE(bestPlaybackProfile(ldacCard), QString("a2dp-sink-sbc_xq"));
+    QCOMPARE(bestPlaybackProfile(ldacCard, "LDAC"), QString("a2dp-sink-ldac"));
+    QCOMPARE(bestPlaybackProfile(ldacCard, "ldac"), QString("a2dp-sink-ldac"));
+
+    // The same card must still fall back for a codec it does not carry at all.
+    QCOMPARE(bestPlaybackProfile(ldacCard, "APTX"), QString("a2dp-sink-sbc_xq"));
 }
 
 QTEST_GUILESS_MAIN(TestProfileChoice)


### PR DESCRIPTION
## Reproduction

AirPods Pro 3 (A3064), Omarchy 4.0.1, PipeWire, Intel controller, plugin 1.3.6.

Playback sounded thin and bass-light. The card was on `a2dp-sink-sbc_xq`. Choosing AAC by
hand fixed the sound and survived, as #29 intends:

```
pactl set-card-profile bluez_card.<addr> a2dp-sink   ->  sounds correct, stays put
```

It does not survive a disconnect. The card goes to `off`, the daemon chooses again, and the
bitrate ranking puts SBC-XQ back:

```
pactl set-card-profile bluez_card.<addr> off
systemctl --user restart librepods
journalctl --user -u librepods | tail -1
  Selected best available output profile: "a2dp-sink-sbc_xq" (codec SBC-XQ)
```

So AAC has to be re-applied by hand after every cold connect. #29 made the daemon stop
overriding an active profile, but a cold connect has no active profile to leave alone.

## The fix

Adds `audio/preferredCodec`, unset by default, which names the codec to use when the daemon
does choose.

## What I ran

Same box, card parked at `off` to force the cold path:

```
preferredCodec unset   ->  Selected best available output profile: "a2dp-sink-sbc_xq" (codec SBC-XQ)
preferredCodec=AAC     ->  Selected best available output profile: "a2dp-sink"        (codec AAC)
```

`cmake --build build`: 0 warnings. `ctest`: 19/19.

Five new cases in `tst_profilechoice.cpp`. I checked each goes red without the change:
removing the preference check reddens them, and so does dropping the playback-candidate
guard from the preference path, which is what keeps a headset codec from reaching the card.

## Behaviour

| Setting | Result |
|---|---|
| unset (default) | unchanged, highest bitrate wins |
| a codec the card lists | that codec, on cold connects too |
| a codec the card does not list | falls back to the ranking, logs which codec it could not honour |
| a headset codec (MSBC, CVSD) | ignored, so it cannot pull the card onto the mic profile |

An already active playback profile is still left alone, so #29 is unchanged.

## Note

The choice lives in `profilechoice.hpp` as pure functions, so the new cases run under
`openpods_add_test` without a sound server. `bestPlaybackProfile` takes the preference as a
defaulted argument, so existing callers and tests are untouched.
