### PR TITLE
fix: rebuild the PulseAudio context after a server restart

### DIFF
--- a/daemon/media/pulseaudiocontroller.cpp
+++ b/daemon/media/pulseaudiocontroller.cpp
@@ -5,10 +5,29 @@
 #include "../snaptogrid.hpp"
 #include <QElapsedTimer>
 #include <QThread>
+#include <algorithm>
+
+namespace
+{
+// Doubling from half a second, capped so a server that stays down keeps polling rather than sleeping through its return.
+constexpr int reconnectBaseDelayMs = 500;
+constexpr int reconnectMaxDoublings = 5;
+
+// Matches the cap in initialize(), so a reconnect gives up on a wedged server as fast as a cold start does.
+constexpr int reconnectReadyTimeoutMs = 5000;
+
+int reconnectDelayMs(int attempt)
+{
+    const int boundedAttempt = std::clamp(attempt, 1, reconnectMaxDoublings);
+    return reconnectBaseDelayMs * (1 << (boundedAttempt - 1));
+}
+}
 
 PulseAudioController::PulseAudioController(QObject *parent)
-    : QObject(parent)
+    : QObject(parent), m_reconnectTimer(new QTimer(this))
 {
+    m_reconnectTimer->setSingleShot(true);
+    connect(m_reconnectTimer, &QTimer::timeout, this, &PulseAudioController::attemptReconnect);
 }
 
 PulseAudioController::~PulseAudioController()
@@ -109,9 +128,91 @@ void PulseAudioController::contextStateCallback(pa_context *c, void *userdata)
     if (!controller || !controller->m_mainloop) return;
     const pa_context_state_t st = pa_context_get_state(c);
     if (st == PA_CONTEXT_FAILED || st == PA_CONTEXT_TERMINATED) {
-        LOG_WARN("PulseAudio context state changed to " << static_cast<int>(st));
+        LOG_WARN("PulseAudio context state changed to " << static_cast<int>(st)
+                 << ", queries will fail until the connection is rebuilt");
+        // Clearing this first makes every query fail fast instead of running against a context libpulse will never revive.
+        controller->m_initialized = false;
+        // This callback runs on the PA mainloop thread holding its lock, so the rebuild has to happen on the Qt thread.
+        QMetaObject::invokeMethod(controller, [controller]() { controller->scheduleReconnect(); },
+                                  Qt::QueuedConnection);
     }
     pa_threaded_mainloop_signal(controller->m_mainloop, 0);
+}
+
+void PulseAudioController::scheduleReconnect()
+{
+    if (m_initialized || !m_mainloop) return;
+    // A pending attempt already owns the ladder, and restarting it here would reset the backoff on every state change.
+    if (m_reconnectTimer->isActive()) return;
+
+    ++m_reconnectAttempts;
+    const int delay = reconnectDelayMs(m_reconnectAttempts);
+    LOG_INFO("Reconnecting to PulseAudio in " << delay << "ms (attempt " << m_reconnectAttempts << ")");
+    m_reconnectTimer->start(delay);
+}
+
+void PulseAudioController::attemptReconnect()
+{
+    if (m_initialized || !m_mainloop) return;
+
+    pa_threaded_mainloop_lock(m_mainloop);
+
+    if (m_context) {
+        pa_context_set_state_callback(m_context, nullptr, nullptr);
+        pa_context_set_subscribe_callback(m_context, nullptr, nullptr);
+        pa_context_disconnect(m_context);
+        pa_context_unref(m_context);
+        m_context = nullptr;
+    }
+
+    pa_mainloop_api *api = pa_threaded_mainloop_get_api(m_mainloop);
+    m_context = pa_context_new(api, "OpenPods");
+    if (!m_context) {
+        pa_threaded_mainloop_unlock(m_mainloop);
+        LOG_ERROR("Failed to create PulseAudio context while reconnecting");
+        scheduleReconnect();
+        return;
+    }
+
+    pa_context_set_state_callback(m_context, contextStateCallback, this);
+
+    if (pa_context_connect(m_context, nullptr, PA_CONTEXT_NOFLAGS, nullptr) < 0) {
+        pa_threaded_mainloop_unlock(m_mainloop);
+        LOG_ERROR("Failed to connect to PulseAudio while reconnecting");
+        scheduleReconnect();
+        return;
+    }
+
+    QElapsedTimer timer; timer.start();
+    while (pa_context_get_state(m_context) != PA_CONTEXT_READY)
+    {
+        if (!PA_CONTEXT_IS_GOOD(pa_context_get_state(m_context)))
+        {
+            pa_threaded_mainloop_unlock(m_mainloop);
+            LOG_ERROR("PulseAudio context failed while reconnecting");
+            scheduleReconnect();
+            return;
+        }
+        if (timer.elapsed() > reconnectReadyTimeoutMs)
+        {
+            pa_threaded_mainloop_unlock(m_mainloop);
+            LOG_ERROR("PulseAudio context did not become ready in 5s while reconnecting");
+            scheduleReconnect();
+            return;
+        }
+        pa_threaded_mainloop_wait(m_mainloop);
+    }
+
+    // The subscription lives on the context, so the volume snap stays dead until it is re-armed on the new one.
+    pa_context_set_subscribe_callback(m_context, &PulseAudioController::subscribeCallback, this);
+    pa_operation *subOp = pa_context_subscribe(
+        m_context, PA_SUBSCRIPTION_MASK_SINK, nullptr, nullptr);
+    if (subOp) pa_operation_unref(subOp);
+
+    pa_threaded_mainloop_unlock(m_mainloop);
+    m_initialized = true;
+    m_reconnectAttempts = 0;
+    LOG_INFO("PulseAudio connection restored");
 }
 
 QString PulseAudioController::getDefaultSink()

--- a/daemon/media/pulseaudiocontroller.cpp
+++ b/daemon/media/pulseaudiocontroller.cpp
@@ -21,6 +21,60 @@ int reconnectDelayMs(int attempt)
     const int boundedAttempt = std::clamp(attempt, 1, reconnectMaxDoublings);
     return reconnectBaseDelayMs * (1 << (boundedAttempt - 1));
 }
+
+// pa_threaded_mainloop_wait() returns only once something signals the mainloop, and the
+// only thing signalling ours is a context state change. A server that accepts the socket
+// and then stalls never produces one, so a bare wait parks the caller forever and the
+// deadline below never gets re-checked. Arming a mainloop time event guarantees the one
+// wakeup the loop needs to notice it has run out of time.
+class MainloopWakeup
+{
+public:
+    MainloopWakeup(pa_threaded_mainloop *mainloop, int timeoutMs)
+        : m_api(pa_threaded_mainloop_get_api(mainloop))
+    {
+        struct timeval tv;
+        pa_gettimeofday(&tv);
+        pa_timeval_add(&tv, static_cast<pa_usec_t>(timeoutMs) * PA_USEC_PER_MSEC);
+        m_event = m_api->time_new(m_api, &tv, &MainloopWakeup::fire, mainloop);
+    }
+
+    // Must run with the mainloop lock still held, which is why the readiness wait is its
+    // own function: every caller unlocks after this goes out of scope, never before.
+    ~MainloopWakeup()
+    {
+        if (m_event) m_api->time_free(m_event);
+    }
+
+    MainloopWakeup(const MainloopWakeup &) = delete;
+    MainloopWakeup &operator=(const MainloopWakeup &) = delete;
+
+private:
+    static void fire(pa_mainloop_api *, pa_time_event *, const struct timeval *, void *userdata)
+    {
+        pa_threaded_mainloop_signal(static_cast<pa_threaded_mainloop*>(userdata), 0);
+    }
+
+    pa_mainloop_api *m_api = nullptr;
+    pa_time_event *m_event = nullptr;
+};
+
+enum class ContextReadiness { Ready, Failed, TimedOut };
+
+// Call with the mainloop lock held; returns with it still held.
+ContextReadiness waitForContextReady(pa_threaded_mainloop *mainloop, pa_context *context, int timeoutMs)
+{
+    MainloopWakeup wakeup(mainloop, timeoutMs);
+
+    QElapsedTimer timer; timer.start();
+    while (pa_context_get_state(context) != PA_CONTEXT_READY)
+    {
+        if (!PA_CONTEXT_IS_GOOD(pa_context_get_state(context))) return ContextReadiness::Failed;
+        if (timer.elapsed() > timeoutMs) return ContextReadiness::TimedOut;
+        pa_threaded_mainloop_wait(mainloop);
+    }
+    return ContextReadiness::Ready;
+}
 }
 
 PulseAudioController::PulseAudioController(QObject *parent)
@@ -85,24 +139,20 @@ bool PulseAudioController::initialize()
     }
 
     // Wait for context to be ready, with a hard cap so a broken daemon
-    // can't freeze startup. pa_threaded_mainloop_wait drops the lock and
-    // wakes on the next signal; cap to ~5s by counting iterations.
-    QElapsedTimer timer; timer.start();
-    constexpr qint64 kInitTimeoutMs = 5000;
-    while (pa_context_get_state(m_context) != PA_CONTEXT_READY)
+    // can't freeze startup.
+    constexpr int kInitTimeoutMs = 5000;
+    switch (waitForContextReady(m_mainloop, m_context, kInitTimeoutMs))
     {
-        if (!PA_CONTEXT_IS_GOOD(pa_context_get_state(m_context)))
-        {
-            LOG_ERROR("PulseAudio context failed");
-            pa_threaded_mainloop_unlock(m_mainloop);
-            return false;
-        }
-        if (timer.elapsed() > kInitTimeoutMs) {
-            LOG_ERROR("PulseAudio context did not become ready in 5s");
-            pa_threaded_mainloop_unlock(m_mainloop);
-            return false;
-        }
-        pa_threaded_mainloop_wait(m_mainloop);
+    case ContextReadiness::Ready:
+        break;
+    case ContextReadiness::Failed:
+        LOG_ERROR("PulseAudio context failed");
+        pa_threaded_mainloop_unlock(m_mainloop);
+        return false;
+    case ContextReadiness::TimedOut:
+        LOG_ERROR("PulseAudio context did not become ready in 5s");
+        pa_threaded_mainloop_unlock(m_mainloop);
+        return false;
     }
 
     // Register sink-event subscription. Fires for every sink change
@@ -116,8 +166,10 @@ bool PulseAudioController::initialize()
         m_context, PA_SUBSCRIPTION_MASK_SINK, nullptr, nullptr);
     if (subOp) pa_operation_unref(subOp);
 
-    pa_threaded_mainloop_unlock(m_mainloop);
+    // Set under the lock: libpulse dispatches state callbacks with it held, so a context
+    // that dies here cannot have its m_initialized = false clobbered by this assignment.
     m_initialized = true;
+    pa_threaded_mainloop_unlock(m_mainloop);
     LOG_INFO("PulseAudio controller initialized");
     return true;
 }
@@ -183,24 +235,20 @@ void PulseAudioController::attemptReconnect()
         return;
     }
 
-    QElapsedTimer timer; timer.start();
-    while (pa_context_get_state(m_context) != PA_CONTEXT_READY)
+    switch (waitForContextReady(m_mainloop, m_context, reconnectReadyTimeoutMs))
     {
-        if (!PA_CONTEXT_IS_GOOD(pa_context_get_state(m_context)))
-        {
-            pa_threaded_mainloop_unlock(m_mainloop);
-            LOG_ERROR("PulseAudio context failed while reconnecting");
-            scheduleReconnect();
-            return;
-        }
-        if (timer.elapsed() > reconnectReadyTimeoutMs)
-        {
-            pa_threaded_mainloop_unlock(m_mainloop);
-            LOG_ERROR("PulseAudio context did not become ready in 5s while reconnecting");
-            scheduleReconnect();
-            return;
-        }
-        pa_threaded_mainloop_wait(m_mainloop);
+    case ContextReadiness::Ready:
+        break;
+    case ContextReadiness::Failed:
+        pa_threaded_mainloop_unlock(m_mainloop);
+        LOG_ERROR("PulseAudio context failed while reconnecting");
+        scheduleReconnect();
+        return;
+    case ContextReadiness::TimedOut:
+        pa_threaded_mainloop_unlock(m_mainloop);
+        LOG_ERROR("PulseAudio context did not become ready in 5s while reconnecting");
+        scheduleReconnect();
+        return;
     }
 
     // The subscription lives on the context, so the volume snap stays dead until it is re-armed on the new one.
@@ -209,9 +257,13 @@ void PulseAudioController::attemptReconnect()
         m_context, PA_SUBSCRIPTION_MASK_SINK, nullptr, nullptr);
     if (subOp) pa_operation_unref(subOp);
 
-    pa_threaded_mainloop_unlock(m_mainloop);
+    // Both set under the lock, for the same reason as in initialize(): releasing first
+    // leaves a window where a dying context queues scheduleReconnect(), this assignment
+    // then re-marks the controller initialized, and the queued call bails on its guard --
+    // stranding a dead context with no retry pending.
     m_initialized = true;
     m_reconnectAttempts = 0;
+    pa_threaded_mainloop_unlock(m_mainloop);
     LOG_INFO("PulseAudio connection restored");
 }
 

--- a/daemon/media/pulseaudiocontroller.h
+++ b/daemon/media/pulseaudiocontroller.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QTimer>
 #include <atomic>
 #include <pulse/pulseaudio.h>
 
@@ -61,7 +62,12 @@ public:
 private:
     pa_threaded_mainloop *m_mainloop = nullptr;
     pa_context *m_context = nullptr;
-    bool m_initialized = false;
+    // Written from the PA mainloop thread on context death, read from the Qt thread by every query.
+    std::atomic<bool> m_initialized{false};
+
+    // A dead context is never revived by libpulse, so recovery builds a new one on the surviving mainloop.
+    QTimer *m_reconnectTimer = nullptr;
+    int m_reconnectAttempts = 0;
 
     // AVRCP 5%-grid snap state. m_snapSinkName empty disables.
     // m_expectedVolume tracks the last daemon-initiated set so the
@@ -85,4 +91,7 @@ private:
     static void snapSinkInfoCallback(pa_context *c, const pa_sink_info *info, int eol, void *userdata);
 
     bool waitForOperation(pa_operation *op);
+
+    void scheduleReconnect();
+    void attemptReconnect();
 };


### PR DESCRIPTION
Closes #46

## Reproduction

On a box with AirPods connected and audio playing, removing one pod pauses playback as expected. Then:

```
systemctl --user restart pipewire pipewire-pulse wireplumber
```

After that, removing a pod never pauses anything, for the remaining life of the daemon. `status.json` keeps publishing correct `in_ear` values throughout, so the panel still looks entirely healthy, which is what makes this hard to attribute.

The daemon logs the cause exactly once, at the second of the restart:

```
PulseAudio context state changed to  5
```

State 5 is `PA_CONTEXT_FAILED`. `contextStateCallback` logged it and returned. `m_initialized` stayed `true`, so none of the `if (!m_initialized)` guards engaged either, and every later query ran against a context libpulse never revives. `getDefaultSink()` then returned `""` forever, so `isActiveOutputDeviceAirPods()` in `mediacontroller.cpp:148` compared an empty string against the device address and returned false permanently. Both the ear detection pause and `activateA2dpProfileWithRetry()` gate on that call, so both became unreachable.

From then on, indefinitely (address redacted):

```
No matching Bluetooth card found for MAC address:  "AA_BB_CC_DD_EE_FF"
Device output name set to:  ""
PulseAudio capture query failed for  "AA_BB_CC_DD_EE_FF" , capture state unknown
Giving up on A2DP profile activation ... the capture query came back unknown  6  times running
```

Restarting the daemon by hand fixed it every time.

## The fix

On `PA_CONTEXT_FAILED` or `PA_CONTEXT_TERMINATED`, clear `m_initialized` so queries fail fast, then rebuild the context on the surviving mainloop from the Qt thread with a capped backoff, re-arming the sink subscription the volume snap depends on.

Three details worth review attention:

- The state callback runs on the PA mainloop thread holding its lock, so the rebuild is posted to the Qt thread with a queued `invokeMethod` rather than done in place. The controller is the context object, so a queued call cannot outlive it.
- `m_initialized` becomes `std::atomic<bool>` because it is now written from the PA mainloop thread and read from the Qt thread by every query. `m_expectedVolume` in the same class is atomic for the same reason.
- The ladder caps rather than exhausting. A bounded budget here would reproduce the shape of #19, where recovery stopped permanently and only a manual restart brought it back.

## What I ran to check it

Build and suite, per CONTRIBUTING:

```
cd daemon && cmake -B build -G Ninja && cmake --build build && ctest --test-dir build
```

Clean build, `100% tests passed out of 19`.

On hardware, restarting only `pipewire-pulse` reproduces the context death while leaving the core and the bluez card up. Before the change the daemon logged the single warning and never recovered. After it:

```
PulseAudio controller initialized
PulseAudio context state changed to  5 , queries will fail until the connection is rebuilt
Reconnecting to PulseAudio in  500 ms (attempt  1 )
PulseAudio connection restored
Device output name set to:  "bluez_card.AA_BB_CC_DD_EE_FF"
Selected best available output profile:  "a2dp-sink-sbc_xq"
```

The card resolution on the line after the restore is the functional check that matters. That is the exact query that returned `""` forever before.

Tested on Arch, kernel 7.1.9, PipeWire 1.6.8, BlueZ 5.87, AirPods Pro 3.

## On testability

No unit test accompanies this. The defect only exists across a real PulseAudio server restart, and `openpods_add_test` links `Qt6::Test` and `Qt6::Core` only, so a case that drove it could not run in this suite. Writing a test for the backoff arithmetic alone would pass with or without the fix, which CONTRIBUTING rightly calls worth nothing, so the hardware trace above stands in its place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio reliability by automatically restoring the PulseAudio connection when it fails or is terminated.
  - Added automatic retry attempts with increasing delays, reducing the need to restart the application after temporary audio service interruptions.
  - Improved startup and reconnection handling so the application no longer waits indefinitely when the audio service does not respond promptly.
  - Restored audio subscriptions after successful reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->