### PR TITLE
fix: duty cycle the BLE scan so HID devices can reconnect

### DIFF
--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -91,7 +91,13 @@ QString getConnectionStateName(BleInfo::ConnectionState state)
 BleManager::BleManager(QObject *parent) : QObject(parent)
 {
     discoveryAgent = new QBluetoothDeviceDiscoveryAgent(this);
-    discoveryAgent->setLowEnergyDiscoveryTimeout(0); // Continuous scanning
+
+    gapTimer = new QTimer(this);
+    gapTimer->setSingleShot(true);
+    connect(gapTimer, &QTimer::timeout, this, [this]() {
+        if (duty.gapFinished())
+            beginWindow();
+    });
 
     connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::deviceDiscovered,
             this, &BleManager::onDeviceDiscovered);
@@ -110,21 +116,36 @@ BleManager::~BleManager()
     // redundant and ran before Qt's own child cleanup pass. Now empty.
 }
 
+void BleManager::beginWindow()
+{
+    discoveryAgent->setLowEnergyDiscoveryTimeout(ScanDuty::windowMs);
+    discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+}
+
 void BleManager::startScan()
 {
+    // Several callers ask for a scan that is already running, and restarting mid-gap would
+    // take back the radio this cycle just handed to whatever is trying to reconnect.
+    if (duty.active())
+        return;
+
     LOG_DEBUG("Starting BLE scan...");
-    discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+    duty.start();
+    beginWindow();
 }
 
 void BleManager::stopScan()
 {
     LOG_DEBUG("Stopping BLE scan...");
+    duty.stop();
+    gapTimer->stop();
     discoveryAgent->stop();
 }
 
+// The gap is still a scan the caller asked for, so callers gating on this must not see it flicker.
 bool BleManager::isScanning() const
 {
-    return discoveryAgent->isActive();
+    return duty.active();
 }
 
 void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
@@ -228,9 +249,9 @@ void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
 
 void BleManager::onScanFinished()
 {
-    if (discoveryAgent->isActive())
+    if (duty.windowFinished())
     {
-        discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+        gapTimer->start(ScanDuty::gapMs);
     }
 }
 

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -255,8 +255,13 @@ void BleManager::onScanFinished()
     }
 }
 
+// A failed window ends the window, not the cycle. Stopping for good was survivable when one
+// scan was started per connect cycle, and is not when a window starts every few seconds.
 void BleManager::onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error)
 {
-    LOG_ERROR("BLE scan error occurred:" << error);
-    stopScan();
+    LOG_ERROR("BLE scan error occurred, retrying after the gap:" << error);
+    if (duty.windowFinished())
+    {
+        gapTimer->start(ScanDuty::gapMs);
+    }
 }

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -7,6 +7,7 @@
 #include <QString>
 #include <QDateTime>
 #include "enums.h"
+#include "../scanduty.hpp"
 
 class QTimer;
 
@@ -83,11 +84,15 @@ signals:
     void deviceFound(const BleInfo &device);
 
 private:
+    void beginWindow();
+
     // Default-init so a partial construction (or a refactor that
     // skips the explicit ctor body) doesn't leave a dangling pointer
     // that start/stop/isScan would dereference. Real assignment
     // happens in BleManager::BleManager() via parented `new`.
     QBluetoothDeviceDiscoveryAgent *discoveryAgent = nullptr;
+    QTimer *gapTimer = nullptr;
+    ScanDuty::Cycle duty;
 };
 
 #endif // BLEMANAGER_H

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -48,6 +48,7 @@
 #include "QRCodeImageProvider.hpp"
 #include "systemsleepmonitor.hpp"
 #include "controlreconnect.hpp"
+#include "scanduty.hpp"
 
 using namespace AirpodsTrayApp::Enums;
 
@@ -707,7 +708,8 @@ public slots:
     }
     void onSystemWakingUp()
     {
-        LOG_INFO("System wake-up; deferring BLE rediscovery 2s for BlueZ to settle");
+        LOG_INFO("System wake-up; deferring BLE rediscovery " << ScanDuty::resumeSettleMs
+                 << "ms for BlueZ and any reconnecting HID device to settle");
 
         // BlueZ + the kernel BT controller often need ~1-3s after resume
         // before hci0 is responsive again. Firing scan + GetManagedObjects
@@ -716,7 +718,10 @@ public slots:
         // and keep m_isSuspending true until the grace window closes so
         // the disconnect notifications that BlueZ fires during resume
         // don't surface as user-visible "AirPods Disconnected" toasts.
-        QTimer::singleShot(2000, this, [this]() {
+        // The wait also covers bonded BLE HID devices, which re-associate in
+        // the first seconds after the controller resets and lose the race
+        // against a scan that starts while they are still advertising.
+        QTimer::singleShot(ScanDuty::resumeSettleMs, this, [this]() {
             // Suspend stopped discovery on every controller, so resume restarts it and the gate below re-applies.
             m_bleManager->startScan();
 

--- a/daemon/scanduty.hpp
+++ b/daemon/scanduty.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+namespace ScanDuty
+{
+// A continuous LE scan holds the radio, and BlueZ answers a connect request on the same
+// controller, so a BLE HID device reconnecting after resume can be starved indefinitely.
+// Scanning half the time leaves gaps wide enough for that reconnect to complete.
+inline constexpr int windowMs = 6000;
+inline constexpr int gapMs = 6000;
+
+// Resume is the worst moment to take the radio back: the controller has just reset and a
+// bonded HID device re-associates in the first seconds after it does.
+inline constexpr int resumeSettleMs = 10000;
+
+enum class Phase
+{
+    Idle,
+    Window,
+    Gap
+};
+
+class Cycle
+{
+public:
+    void start() { m_phase = Phase::Window; }
+    void stop() { m_phase = Phase::Idle; }
+
+    bool active() const { return m_phase != Phase::Idle; }
+    Phase phase() const { return m_phase; }
+
+    // True when the caller must time a gap. A stop that raced the agent's finished signal
+    // leaves the cycle idle, and restarting it there would resume a scan nobody asked for.
+    bool windowFinished()
+    {
+        if (m_phase != Phase::Window) {
+            return false;
+        }
+        m_phase = Phase::Gap;
+        return true;
+    }
+
+    // True when the caller must scan again.
+    bool gapFinished()
+    {
+        if (m_phase != Phase::Gap) {
+            return false;
+        }
+        m_phase = Phase::Window;
+        return true;
+    }
+
+private:
+    Phase m_phase = Phase::Idle;
+};
+}

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -77,6 +77,11 @@ openpods_add_test(tst_controlreconnect
     ../controlreconnect.hpp
 )
 
+openpods_add_test(tst_scanduty
+    tst_scanduty.cpp
+    ../scanduty.hpp
+)
+
 openpods_add_test(tst_snaptogrid
     tst_snaptogrid.cpp
     ../snaptogrid.hpp

--- a/daemon/tests/tst_scanduty.cpp
+++ b/daemon/tests/tst_scanduty.cpp
@@ -1,0 +1,78 @@
+#include <QtTest>
+
+#include "../scanduty.hpp"
+
+class TestScanDuty : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void yieldsTheRadioBetweenWindows()
+    {
+        // The defect this replaces: the agent ran with a 0ms timeout, so the scan never
+        // ended and a reconnecting BLE HID device never got the radio.
+        ScanDuty::Cycle cycle;
+        cycle.start();
+        QCOMPARE(cycle.phase(), ScanDuty::Phase::Window);
+
+        QVERIFY(cycle.windowFinished());
+        QCOMPARE(cycle.phase(), ScanDuty::Phase::Gap);
+        QVERIFY(cycle.active());
+
+        QVERIFY(cycle.gapFinished());
+        QCOMPARE(cycle.phase(), ScanDuty::Phase::Window);
+    }
+
+    void leavesTheRadioIdleForAtLeastHalfTheCycle()
+    {
+        QVERIFY(ScanDuty::gapMs >= ScanDuty::windowMs);
+        QVERIFY(ScanDuty::resumeSettleMs > ScanDuty::gapMs);
+    }
+
+    void staysStoppedWhenTheAgentReportsFinishedAfterAStop()
+    {
+        // stopScan() cancels the agent, and the cancellation arrives as a signal. Treating
+        // it as the end of a window would restart a scan the caller just switched off.
+        ScanDuty::Cycle cycle;
+        cycle.start();
+        cycle.stop();
+
+        QVERIFY(!cycle.windowFinished());
+        QVERIFY(!cycle.active());
+        QCOMPARE(cycle.phase(), ScanDuty::Phase::Idle);
+    }
+
+    void staysStoppedWhenAGapTimerFiresAfterAStop()
+    {
+        ScanDuty::Cycle cycle;
+        cycle.start();
+        QVERIFY(cycle.windowFinished());
+        cycle.stop();
+
+        QVERIFY(!cycle.gapFinished());
+        QVERIFY(!cycle.active());
+    }
+
+    void ignoresAGapThatEndsTwice()
+    {
+        ScanDuty::Cycle cycle;
+        cycle.start();
+        QVERIFY(cycle.windowFinished());
+        QVERIFY(cycle.gapFinished());
+
+        // Already scanning again, so a duplicate timeout must not re-arm anything.
+        QVERIFY(!cycle.gapFinished());
+        QCOMPARE(cycle.phase(), ScanDuty::Phase::Window);
+    }
+
+    void startsIdle()
+    {
+        ScanDuty::Cycle cycle;
+        QVERIFY(!cycle.active());
+        QVERIFY(!cycle.windowFinished());
+        QVERIFY(!cycle.gapFinished());
+    }
+};
+
+QTEST_GUILESS_MAIN(TestScanDuty)
+#include "tst_scanduty.moc"


### PR DESCRIPTION
## The defect

A bonded Bluetooth LE mouse stops reconnecting after every resume once this daemon
is running. The symptom at the desk is that the mouse is dead on unlock and the
only thing that appears to help is removing the device and pairing it again.

`BleManager` created the discovery agent with `setLowEnergyDiscoveryTimeout(0)`,
commented "Continuous scanning". Whenever the pods are not connected, and that is
most of the day, the scan runs forever. BlueZ serves connect requests on the same
controller, so a bonded LE HID device re-associating after resume loses the radio
and never gets it back.

`onSystemWakingUp` made it reliable rather than occasional: it restarted the scan
2s after wake, which is exactly the window a bonded HID device uses to
re-associate.

The project already knew a live scan blocks connects. `main.cpp` says so above the
control link recovery: "A live scan delays the L2CAP connect this recovery depends
on, so pause it and restore after." The same is true for HID, which had no such
pause.

## Reproduction, on real hardware

Logitech MX Master 4, LE only (`SupportedTechnologies=LE` in the BlueZ bond),
MediaTek controller, laptop resumed from suspend with the daemon running.

Daemon running, adapter reporting `Discovering: yes`:

```
$ timeout 25 bluetoothctl connect <mouse>
Attempting to connect to <mouse>
(no further output, killed at 25s)
```

Same device, same session, daemon stopped:

```
$ systemctl --user stop librepods.service
$ bluetoothctl show | grep Discovering
        Discovering: no
$ bluetoothctl connect <mouse>
Connection successful
```

The daemon log showed one `deferring BLE rediscovery 2s for BlueZ to settle` per
resume, five that day, matching one dead mouse per unlock.

The bond itself was intact throughout, valid LE Secure Connections keys with
`Authenticated=2`. Removing and re-pairing was never actually necessary, it just
happened to force a directed connection that won the race.

## The fix

Duty cycle the scan, 6s on and 6s off, so the radio is free half the time, and
wait 10s after resume before scanning so a reconnecting HID device goes first.

The phase machine lives in `daemon/scanduty.hpp` rather than in `BleManager`,
because `openpods_add_test` links only `Qt6::Test` and `Qt6::Core` and a state
machine inside the agent wrapper could not be tested. Same shape as
`controlreconnect.hpp`.

`isScanning()` now reports the cycle's intent rather than the agent's instantaneous
state, so the existing callers that gate on it do not see it flicker off during
every gap.

## What I ran

Full suite, 20/20 passing, including the new `tst_scanduty`.

The new cases were checked red, since a case that passes either way is worth
nothing:

- `gapMs = 0`, which is the old continuous behaviour, fails
  `leavesTheRadioIdleForAtLeastHalfTheCycle`.
- Deleting the two post-stop phase guards fails 4 of the 6 cases, including
  `staysStoppedWhenTheAgentReportsFinishedAfterAStop`, which covers the agent
  reporting finished after `stopScan()` cancelled it.

On the box, with the new build installed and the daemon running:

```
$ for i in $(seq 1 10); do bluetoothctl show | grep -oP 'Discovering: \K\w+'; sleep 2; done
yes yes no no no yes yes yes no no

$ bluetoothctl connect <mouse>
Connection successful      (0s, previously hung past 25s)
```

## What I did not drive

I have not yet driven a full suspend and resume cycle against the new build, only
the connect starvation that resume triggers. The 10s resume settle is therefore
reasoned from the 2s value that reproduced the failure, not measured against a
suspend. Worth a second pair of eyes, and easy to raise if it proves short.

## Trade-off

Battery updates now arrive with up to about 12s of latency instead of
continuously, and about 10s after resume. `windowMs` and `gapMs` are named
constants if you would rather bias differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * BLE scanning now uses scheduled scan windows and idle intervals to reduce radio activity and power consumption.
  * Scanning reliably stops when requested and avoids duplicate restart attempts.
  * Device reconnection after system wake-up uses an updated settling interval.

* **Tests**
  * Added coverage for scan-cycle transitions, stopping behavior, timing, and duplicate timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->