### PR TITLE
fix: let the idle BLE scan be switched off

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ opening anything.
 | Hide when disconnected | on | Leaves the bar entirely rather than sitting there with nothing to say. |
 | Path to librepods-ctl | empty | Leave empty to find it on `PATH`. |
 
+The daemon has one setting of its own, in `~/.config/AirPodsTrayApp/AirPodsTrayApp.conf`:
+
+```ini
+[bluetooth]
+idleScan=false
+```
+
+While the pods are disconnected the daemon normally keeps a BLE discovery session open
+to read battery, lid and ear state from their advertisements. On Linux an open discovery
+session stops other bonded LE devices from reconnecting, so a keyboard or mouse can stay
+dead until the pods connect. Set `idleScan=false` to give that up: everything works as
+before while the pods are connected, and the panel shows no battery while they are not.
+Restart `librepods.service` after changing it.
+
 ## Tests
 
 `Model.js` holds the parsing and formatting, with no QML imports, so it runs

--- a/daemon/idlescan.hpp
+++ b/daemon/idlescan.hpp
@@ -1,0 +1,15 @@
+#ifndef IDLESCAN_HPP
+#define IDLESCAN_HPP
+
+#include <QSettings>
+
+// The idle BLE scan is an active discovery session, and while one is open the kernel never arms
+// the passive scan that bonded LE devices reconnect through, so a mouse or keyboard stays dead
+// for as long as the pods are away. Off, battery, lid and ear state come over the control link
+// only, and are unknown while the pods are disconnected.
+inline bool idleScanEnabled(const QSettings &settings)
+{
+    return settings.value("bluetooth/idleScan", true).toBool();
+}
+
+#endif // IDLESCAN_HPP

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -48,6 +48,7 @@
 #include "QRCodeImageProvider.hpp"
 #include "systemsleepmonitor.hpp"
 #include "controlreconnect.hpp"
+#include "idlescan.hpp"
 
 using namespace AirpodsTrayApp::Enums;
 
@@ -674,6 +675,17 @@ public slots:
         }
     }
 
+    // Every idle scan start comes through here. The control link recovery is separate: it only
+    // restores a scan it found running, so a disabled scan stays off across a reconnect.
+    void startIdleScan()
+    {
+        if (!idleScanEnabled(*m_settings)) {
+            LOG_INFO("Idle BLE scan is off (bluetooth/idleScan=false), leaving discovery to BlueZ");
+            return;
+        }
+        m_bleManager->startScan();
+    }
+
     bool loadCrossDeviceEnabled() { return m_settings->value("crossdevice/enabled", false).toBool(); }
     void saveCrossDeviceEnabled() { m_settings->setValue("crossdevice/enabled", CrossDevice.isEnabled); }
 
@@ -718,7 +730,7 @@ public slots:
         // don't surface as user-visible "AirPods Disconnected" toasts.
         QTimer::singleShot(2000, this, [this]() {
             // Suspend stopped discovery on every controller, so resume restarts it and the gate below re-applies.
-            m_bleManager->startScan();
+            startIdleScan();
 
             if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
             {
@@ -859,7 +871,7 @@ private slots:
 
         // Clear the device name and model
         m_deviceInfo->reset();
-        m_bleManager->startScan();
+        startIdleScan();
         emit airPodsStatusChanged();
 
         // Skip the disconnect toast if we're suspending/resuming — BlueZ
@@ -1595,7 +1607,7 @@ public:
 
         m_deviceInfo->loadFromSettings(*m_settings);
         // Unreachable with the pods already connected: the constructor returns before this.
-        m_bleManager->startScan();
+        startIdleScan();
     }
 
     // Null engine is the headless run, where there is no window to open and nothing to say about it.

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -77,6 +77,11 @@ openpods_add_test(tst_controlreconnect
     ../controlreconnect.hpp
 )
 
+openpods_add_test(tst_idlescan
+    tst_idlescan.cpp
+    ../idlescan.hpp
+)
+
 openpods_add_test(tst_snaptogrid
     tst_snaptogrid.cpp
     ../snaptogrid.hpp

--- a/daemon/tests/tst_idlescan.cpp
+++ b/daemon/tests/tst_idlescan.cpp
@@ -1,0 +1,42 @@
+#include <QtTest>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include "../idlescan.hpp"
+
+class TestIdleScan : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void defaultsToOn();
+    void offWhenSetFalse();
+};
+
+static QString settingsPath(const QTemporaryDir &dir)
+{
+    return dir.filePath("AirPodsTrayApp.conf");
+}
+
+void TestIdleScan::defaultsToOn()
+{
+    QTemporaryDir dir;
+    QSettings settings(settingsPath(dir), QSettings::IniFormat);
+
+    QVERIFY(idleScanEnabled(settings));
+}
+
+void TestIdleScan::offWhenSetFalse()
+{
+    QTemporaryDir dir;
+    {
+        QSettings written(settingsPath(dir), QSettings::IniFormat);
+        written.setValue("bluetooth/idleScan", false);
+    }
+    QSettings settings(settingsPath(dir), QSettings::IniFormat);
+
+    QVERIFY(!idleScanEnabled(settings));
+}
+
+QTEST_GUILESS_MAIN(TestIdleScan)
+#include "tst_idlescan.moc"


### PR DESCRIPTION
## The defect

Two bonded LE input devices, a Logitech MX Master 4 and a Pebble Keys 2 K380s, stopped reconnecting after reboot and after resume from the day this plugin was installed. They stayed `Paired: yes, Connected: no` until forgotten and paired again, which made the bonds look corrupt. They were fine. This is #44, and the second half of what #49 reported.

## Why

With the pods disconnected, `BleManager` holds an LE discovery session open for as long as the daemon runs. The kernel never arms its passive accept-list scan while any discovery session is open: `hci_update_passive_scan_sync()` in `net/bluetooth/hci_sync.c` returns early unless `hdev->discovery.state == DISCOVERY_STOPPED`, with the comment "If discovery is active don't interfere with it". That passive scan is how a bonded LE peripheral auto-reconnects, so the daemon's idle scan and the keyboard's reconnect are mutually exclusive for as long as the pods are in the case.

## Reproduction, on real hardware

Omarchy 4.0.2 (Arch), BlueZ 5.87-2, kernel 7.1.9-arch1-2, Intel controller (hci0, HW/SW 0x008a008a), plugin 1.3.6 at `fff7fec`, daemon built by `setup`.

Toggling the stock daemon flips the adapter deterministically, nothing else running a scan:

```
$ bluetoothctl show | grep Discovering
        Discovering: yes
$ systemctl --user stop librepods.service; sleep 2; bluetoothctl show | grep Discovering
        Discovering: no
$ systemctl --user start librepods.service; sleep 3; bluetoothctl show | grep Discovering
        Discovering: yes
```

Across twelve boots in the journal, the two boots where the peripherals attached within seconds are the two where they attached before `librepods.service` had started (+4 s and +8 s after `HCI device and connection manager initialized`). Every boot where the daemon was already scanning either took one to three minutes or never attached at all: three boots never did, and in one of them the devices stayed dead for eight hours until they were re-paired the next morning.

## The fix

One daemon setting, `bluetooth/idleScan`, default `true` so nothing changes for anyone who does not set it. Off, the three idle starts (daemon start with no pods, pods disconnecting, resume from suspend) skip the scan. The control link recovery is untouched: it restores only a scan it found running, so a disabled scan stays off across a reconnect.

This is option 2 from #44. It composes with the duty cycle in #39 and #48 (option 1) rather than competing with it: a duty cycle shrinks the window in which a peripheral loses the race, this removes the race for users who would rather have a working mouse than case battery while the pods are away.

## What I verified

- `tst_idlescan` was written first and went red: CMake could not find `idlescan.hpp`. Then the header, green. Full build 0 warnings, `ctest` 20/20.
- Patched daemon, `idleScan=false`, running: the journal shows `Idle BLE scan is off (bluetooth/idleScan=false), leaving discovery to BlueZ` and `bluetoothctl show` reports `Discovering: no` with the service active. Same box, same session, stock daemon reported `yes`.
- Boot this morning with the daemon held back from scanning until the input devices were up: MX Master 4 attached at +4 s and Pebble Keys at +8 s after the controller came up, with `librepods.service` active from +6 s.

## What I did not verify, stated plainly

- Pods connecting with the scan off. My reading of `main.cpp` is that the control link never depends on the scan: `bluezDeviceConnected()` fires from the BlueZ `PropertiesChanged` monitor and calls `connectToDevice()`, and the watchdog sweeps `GetManagedObjects` for a device BlueZ announced no transition for. `bleDeviceFound()` only feeds battery, lid and ear state. I have not had the pods in range since installing the patch, so that is a code reading, not a run. I will add the result here as soon as I have it.
- The daemon still constructs `QBluetoothDeviceDiscoveryAgent`, so the `Missing CAP_NET_ADMIN` line at start is unchanged.

## Assumptions a reviewer can check

- Assumes the passive scan is the only auto-reconnect path for bonded LE devices, so nothing else reconnects them while discovery is open. `check_pending_le_conn()` in `hci_event.c` does also fire on advertising reports during an active scan; in practice, on this controller, that path connected the peripherals in one to three minutes or not at all, which matches the btmon reading in #44.
- Assumes `finishControlRecovery()` is the only other caller of `startScan()`, and that its restore flag is `false` whenever the scan was already off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `idleScan` setting to control Bluetooth scanning while earbuds are disconnected.
  - Scanning remains enabled by default; disabling it prevents disconnected battery status from being displayed and may allow other Bluetooth devices to reconnect.
  - Documented the setting and the required service restart after changing it.

- **Tests**
  - Added coverage for the default and disabled scanning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->