### PR TITLE
Cycle passive BLE scan windows instead of scanning continuously

### DIFF
--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -7,6 +7,8 @@
 
 // Fixed header data[0] through data[10], then a 16-byte encrypted payload.
 static constexpr int proximityPairingBytes = 11 + 16;
+static constexpr int scanWindowMs = 4000;
+static constexpr int scanIdleMs = 8000;
 
 AirpodsTrayApp::Enums::AirPodsModel getModelName(quint16 modelId)
 {
@@ -91,7 +93,11 @@ QString getConnectionStateName(BleInfo::ConnectionState state)
 BleManager::BleManager(QObject *parent) : QObject(parent)
 {
     discoveryAgent = new QBluetoothDeviceDiscoveryAgent(this);
-    discoveryAgent->setLowEnergyDiscoveryTimeout(0); // Continuous scanning
+    discoveryAgent->setLowEnergyDiscoveryTimeout(scanWindowMs);
+
+    rescanTimer = new QTimer(this);
+    rescanTimer->setSingleShot(true);
+    connect(rescanTimer, &QTimer::timeout, this, &BleManager::beginScanWindow);
 
     connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::deviceDiscovered,
             this, &BleManager::onDeviceDiscovered);
@@ -110,21 +116,32 @@ BleManager::~BleManager()
     // redundant and ran before Qt's own child cleanup pass. Now empty.
 }
 
+void BleManager::beginScanWindow()
+{
+    if (!scanRequested || discoveryAgent->isActive())
+        return;
+    discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+}
+
 void BleManager::startScan()
 {
     LOG_DEBUG("Starting BLE scan...");
-    discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+    scanRequested = true;
+    rescanTimer->stop();
+    beginScanWindow();
 }
 
 void BleManager::stopScan()
 {
     LOG_DEBUG("Stopping BLE scan...");
+    scanRequested = false;
+    rescanTimer->stop();
     discoveryAgent->stop();
 }
 
 bool BleManager::isScanning() const
 {
-    return discoveryAgent->isActive();
+    return scanRequested || discoveryAgent->isActive();
 }
 
 void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
@@ -228,10 +245,9 @@ void BleManager::onDeviceDiscovered(const QBluetoothDeviceInfo &info)
 
 void BleManager::onScanFinished()
 {
-    if (discoveryAgent->isActive())
-    {
-        discoveryAgent->start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
-    }
+    // The idle gap lets BlueZ re-arm passive scanning for bonded LE devices.
+    if (scanRequested)
+        rescanTimer->start(scanIdleMs);
 }
 
 void BleManager::onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error)

--- a/daemon/ble/blemanager.cpp
+++ b/daemon/ble/blemanager.cpp
@@ -94,6 +94,11 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
 {
     discoveryAgent = new QBluetoothDeviceDiscoveryAgent(this);
     discoveryAgent->setLowEnergyDiscoveryTimeout(scanWindowMs);
+    // -1 means this platform will not be told how long to scan for. The window
+    // is then whatever the backend chooses; the idle gap after it still
+    // applies, so say so rather than appearing to have set something.
+    if (discoveryAgent->lowEnergyDiscoveryTimeout() == -1)
+        LOG_DEBUG("Platform ignores the LE discovery timeout; scan window length is backend-defined");
 
     rescanTimer = new QTimer(this);
     rescanTimer->setSingleShot(true);
@@ -103,6 +108,10 @@ BleManager::BleManager(QObject *parent) : QObject(parent)
             this, &BleManager::onDeviceDiscovered);
     connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::finished,
             this, &BleManager::onScanFinished);
+    // stop() ends a window with canceled(), never finished(). Without this a
+    // scan asked for while a stop is still in flight is dropped on the floor.
+    connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::canceled,
+            this, &BleManager::onScanCanceled);
     connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::errorOccurred,
             this, &BleManager::onErrorOccurred);
 }
@@ -248,6 +257,15 @@ void BleManager::onScanFinished()
     // The idle gap lets BlueZ re-arm passive scanning for bonded LE devices.
     if (scanRequested)
         rescanTimer->start(scanIdleMs);
+}
+
+void BleManager::onScanCanceled()
+{
+    // startScan() during a cancellation finds isActive() still true and backs
+    // off, expecting to be resumed. Cancellation is that moment; without it
+    // scanning stays dead until something else asks again.
+    if (scanRequested)
+        beginScanWindow();
 }
 
 void BleManager::onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error)

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -77,6 +77,7 @@ public:
 private slots:
     void onDeviceDiscovered(const QBluetoothDeviceInfo &info);
     void onScanFinished();
+    void onScanCanceled();
     void onErrorOccurred(QBluetoothDeviceDiscoveryAgent::Error error);
 
 signals:

--- a/daemon/ble/blemanager.h
+++ b/daemon/ble/blemanager.h
@@ -83,11 +83,15 @@ signals:
     void deviceFound(const BleInfo &device);
 
 private:
+    void beginScanWindow();
+
     // Default-init so a partial construction (or a refactor that
     // skips the explicit ctor body) doesn't leave a dangling pointer
     // that start/stop/isScan would dereference. Real assignment
     // happens in BleManager::BleManager() via parented `new`.
     QBluetoothDeviceDiscoveryAgent *discoveryAgent = nullptr;
+    QTimer *rescanTimer = nullptr;
+    bool scanRequested = false;
 };
 
 #endif // BLEMANAGER_H


### PR DESCRIPTION
Thank you for OmaPods — getting AirPods battery and controls onto Linux at all is impressive work, and having it on the bar is genuinely one of the nicer things about my desktop. This is one fix from running it daily.

## The problem

`BleManager` sets `setLowEnergyDiscoveryTimeout(0)` for continuous scanning, and `onScanFinished()` immediately restarts discovery. BlueZ is left scanning without pause, which stops it re-arming passive scanning for already-bonded LE devices.

## The change

Use a bounded discovery window (4s) with an idle gap (8s) between windows, driven by a single-shot timer:

- `startScan()` sets a `scanRequested` flag and opens a window.
- `onScanFinished()` re-arms the timer instead of restarting discovery immediately, so BlueZ gets the idle gap it needs.
- `stopScan()` clears the flag and the timer, so a stop is a real stop.
- `isScanning()` reports the *intent* (`scanRequested || isActive()`), so it stays true across the idle gap rather than flickering false between windows.

The two intervals are named constants at the top of the file, so they're easy to tune if 4s/8s isn't the right balance on other hardware.

I've tested this against my own set; I can't speak for every model, so please treat the timings as a starting point rather than a recommendation. Happy to adjust the approach if you'd rather handle the re-arm a different way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT7trpn4vaR9Yj4yLdPjd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * BLE scanning now runs in short scan windows instead of continuously.
  * Scans automatically resume after an idle interval when scanning remains requested.
  * Scanning status more accurately reflects when a scan has been requested.
  * Scanning can recover and resume after a scan is canceled.
  * Scan timing is better aligned with device discovery activity, reducing unnecessary continuous scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->