### PR TITLE
fix: make the AirPods Max support we already have run

### DIFF
--- a/daemon/BluetoothMonitor.cpp
+++ b/daemon/BluetoothMonitor.cpp
@@ -74,14 +74,33 @@ QString BluetoothMonitor::getDeviceName(const QString &devicePath)
     return "Unknown";
 }
 
-bool BluetoothMonitor::checkAlreadyConnectedDevices()
+void BluetoothMonitor::checkAlreadyConnectedDevices(const QString &logOnFound)
 {
+    // A blocking call would stall the event loop for the whole timeout against a wedged
+    // bluetoothd, and the watchdog repeats this every 30 s while the control link is down.
+    if (m_sweepInFlight) {
+        return;
+    }
+
     // QDBusInterface introspects the remote object from its constructor on the default 25 s
     // timeout, so setTimeout on the interface cannot bound this. Build the call directly.
     QDBusMessage request = QDBusMessage::createMethodCall(
         "org.bluez", "/", "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
-    QDBusMessage reply = m_dbus.call(request, QDBus::Block, sweepTimeoutMs);
+    auto *watcher = new QDBusPendingCallWatcher(m_dbus.asyncCall(request, sweepTimeoutMs), this);
+    m_sweepInFlight = true;
 
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, logOnFound](QDBusPendingCallWatcher *call) {
+                m_sweepInFlight = false;
+                call->deleteLater();
+                if (consumeSweepReply(call->reply()) && !logOnFound.isEmpty()) {
+                    LOG_INFO(qUtf8Printable(logOnFound));
+                }
+            });
+}
+
+bool BluetoothMonitor::consumeSweepReply(const QDBusMessage &reply)
+{
     if (reply.type() == QDBusMessage::ErrorMessage)
     {
         // Keyed on the name as well, since an error reply carrying no string reads empty.

--- a/daemon/BluetoothMonitor.cpp
+++ b/daemon/BluetoothMonitor.cpp
@@ -56,6 +56,8 @@ bool BluetoothMonitor::isAirPodsDevice(const QString &devicePath)
     QDBusInterface deviceInterface("org.bluez", devicePath, "org.freedesktop.DBus.Properties", m_dbus);
     QDBusReply<QVariant> uuidsReply = deviceInterface.call("Get", "org.bluez.Device1", "UUIDs");
     if (!uuidsReply.isValid()) {
+        LOG_WARN("BlueZ UUID query failed for " << devicePath << ": "
+                                                << uuidsReply.error().message());
         return false;
     }
     QStringList uuids = uuidsReply.value().toStringList();
@@ -193,6 +195,7 @@ void BluetoothMonitor::onPropertiesChanged(const QDBusMessage &message)
     QDBusInterface deviceInterface("org.bluez", path, "org.freedesktop.DBus.Properties", m_dbus);
     QDBusReply<QVariant> addrReply = deviceInterface.call("Get", "org.bluez.Device1", "Address");
     if (!addrReply.isValid()) {
+        LOG_WARN("BlueZ Address query failed for " << path << ": " << addrReply.error().message());
         return;
     }
 

--- a/daemon/BluetoothMonitor.h
+++ b/daemon/BluetoothMonitor.h
@@ -15,7 +15,8 @@ public:
     explicit BluetoothMonitor(QObject *parent = nullptr);
     ~BluetoothMonitor() override;
 
-    bool checkAlreadyConnectedDevices();
+    // Logs logOnFound when the sweep adopts something, so each caller names its own reason.
+    void checkAlreadyConnectedDevices(const QString &logOnFound = QString());
     void probeDeviceConnected(const QString &macAddress, quint64 requestId);
 
 signals:
@@ -34,9 +35,12 @@ private:
     QDBusConnection m_dbus;
     // The watchdog repeats the sweep, so only a change of error is worth logging again.
     QString m_lastSweepError;
+    // One sweep at a time, since the watchdog fires again every 30 s while the link is down.
+    bool m_sweepInFlight = false;
     void registerDBusService();
     bool isAirPodsDevice(const QString &devicePath);
     QString getDeviceName(const QString &devicePath);
+    bool consumeSweepReply(const QDBusMessage &reply);
 };
 
 #endif // BLUETOOTHMONITOR_H

--- a/daemon/controlreconnect.hpp
+++ b/daemon/controlreconnect.hpp
@@ -37,12 +37,12 @@ inline bool shouldRetryFromWatchdog(bool controlSocketConnected, bool recoveryAc
            && haveAddress && bluezReportedConnected;
 }
 
-// A cold start before BlueZ has an adapter learns no address, and BlueZ emits no Connected
-// transition for a device whose object is created already connected, so nothing else fires.
+// BlueZ emits no Connected transition for a device whose object is created already connected
+// (cold start before the adapter, an adapter power cycle, a second pair), so an idle daemon polls.
 inline bool shouldRescanFromWatchdog(bool controlSocketConnected, bool recoveryActive,
-                                     bool suspending, bool haveAddress)
+                                     bool suspending)
 {
-    return !controlSocketConnected && !recoveryActive && !suspending && !haveAddress;
+    return !controlSocketConnected && !recoveryActive && !suspending;
 }
 
 inline int delayMs(int attempt, int jitterMs)

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -910,28 +910,25 @@ private slots:
         }
     }
 
-    // Gated on the last probe answer, so pods that are merely away cannot restart the ladder every tick.
+    // The ladder is retried only on the last probe answer, so pods merely away cannot restart it.
     void checkControlLinkWatchdog()
     {
-        if (ControlReconnect::shouldRescanFromWatchdog(
-                areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending,
-                !m_lastAirPodsAddress.isEmpty())) {
-            if (monitor->checkAlreadyConnectedDevices()) {
-                LOG_INFO("Control link watchdog: swept up AirPods that no BlueZ signal announced");
-            }
-            return;
-        }
-
-        if (!ControlReconnect::shouldRetryFromWatchdog(
+        if (ControlReconnect::shouldRetryFromWatchdog(
                 areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending,
                 !m_lastAirPodsAddress.isEmpty(), m_bluezReportedConnected)) {
+            LOG_INFO("Control link watchdog: last BlueZ probe said connected, retrying "
+                     << m_lastAirPodsAddress);
+            scheduleControlReconnect(m_lastAirPodsAddress, m_lastAirPodsName,
+                                     QStringLiteral("watchdog recheck"));
             return;
         }
 
-        LOG_INFO("Control link watchdog: last BlueZ probe said connected, retrying "
-                 << m_lastAirPodsAddress);
-        scheduleControlReconnect(m_lastAirPodsAddress, m_lastAirPodsName,
-                                 QStringLiteral("watchdog recheck"));
+        // A pair BlueZ already holds emits no transition here, so only a sweep can find it.
+        if (ControlReconnect::shouldRescanFromWatchdog(
+                areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending)
+            && monitor->checkAlreadyConnectedDevices()) {
+            LOG_INFO("Control link watchdog: swept up AirPods that no BlueZ signal announced");
+        }
     }
 
     void attemptControlReconnect()

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -925,9 +925,9 @@ private slots:
 
         // A pair BlueZ already holds emits no transition here, so only a sweep can find it.
         if (ControlReconnect::shouldRescanFromWatchdog(
-                areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending)
-            && monitor->checkAlreadyConnectedDevices()) {
-            LOG_INFO("Control link watchdog: swept up AirPods that no BlueZ signal announced");
+                areAirpodsConnected(), m_controlRecovery.isActive(), m_isSuspending)) {
+            monitor->checkAlreadyConnectedDevices(
+                QStringLiteral("Control link watchdog: swept up AirPods that no BlueZ signal announced"));
         }
     }
 

--- a/daemon/tests/tst_controlreconnect.cpp
+++ b/daemon/tests/tst_controlreconnect.cpp
@@ -43,19 +43,17 @@ private slots:
         QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, false, false, false, true));
     }
 
-    void watchdogSweepsBlueZWhenTheDaemonStartedBeforeTheAdapter()
+    void watchdogSweepsBlueZWheneverTheControlLinkIsDown()
     {
         // Cold start with the adapter down: no address was ever learned, so the retry ladder cannot run.
         QVERIFY(!ControlReconnect::shouldRetryFromWatchdog(false, false, false, false, false));
-        QVERIFY(ControlReconnect::shouldRescanFromWatchdog(false, false, false, false));
-
-        // An address in hand means the retry ladder owns the tick, so the sweep stands down.
-        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, false, false, true));
+        // The same answer with an address in hand: a second pair after a power cycle arrives with no transition.
+        QVERIFY(ControlReconnect::shouldRescanFromWatchdog(false, false, false));
 
         // Every other guard still vetoes on its own.
-        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(true, false, false, false));
-        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, true, false, false));
-        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, false, true, false));
+        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(true, false, false));
+        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, true, false));
+        QVERIFY(!ControlReconnect::shouldRescanFromWatchdog(false, false, true));
     }
 
     void tracksRecoveryLifecycle()


### PR DESCRIPTION
BlueZ held my AirPods Max connected for 91 minutes while `librepods-ctl status` said `connected:false`, with `model_name` stuck on the pair that connected earlier that day. The daemon logged nothing in that window, about 180 watchdog ticks.

`shouldRescanFromWatchdog` carried a `!haveAddress` term, and `m_lastAirPodsAddress` is set on the first connect and never cleared, so after any pair connects once the sweep never runs again. An adapter power cycle does not always give you the `Connected` transition that was then the only route left.

This drops the term and puts the retry ladder first so it keeps the tick it already owned. The two silent D-Bus failures on that path now log why.

Checks: `ctest` 19/19, and the rewritten case fails without the header change. No hand reproduction worked, so I dropped the `Connected` signal behind an env var in a throwaway build: `main` sat for 84 seconds, the fix swept the device up. Not tested: two pairs at once, my other pair was in its case.
