### PR TITLE
fix: name ear detection for a thing worn on the head

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -193,9 +193,10 @@ function earDetectionVerb(behavior) {
   return verbs[behavior]
 }
 
-function earDetectionName(behavior) {
-  if (behavior === EAR_PAUSE_ONE_OUT) return "Pause when one is out"
-  if (behavior === EAR_PAUSE_BOTH_OUT) return "Pause when both are out"
+// A headset has no pods to take out, so the same daemon rules get named for a thing worn on the head.
+function earDetectionName(behavior, isHeadset) {
+  if (behavior === EAR_PAUSE_ONE_OUT) return isHeadset ? "Pause when either side is off" : "Pause when one is out"
+  if (behavior === EAR_PAUSE_BOTH_OUT) return isHeadset ? "Pause when taken off" : "Pause when both are out"
   if (behavior === EAR_DISABLED) return "Never pause"
   return "Unknown"
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -351,7 +351,7 @@ Panel {
               width: parent.width
               rowName: "ear"
               label: "Ear detection"
-              value: Model.earDetectionName(pods.earDetectionBehavior)
+              value: Model.earDetectionName(pods.earDetectionBehavior, pods.isHeadset)
             }
           }
 

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -3,7 +3,7 @@
 
 const source = Deno.readTextFileSync(new URL("../Model.js", import.meta.url))
 const Model = new Function(
-  source + "; return { parseStatus, podFrom, defaultPod, noiseModeVerb, earDetectionVerb, levelFraction, levelText, podMeta, elideError, availableModes, NOISE_OFF, NOISE_ANC, NOISE_TRANSPARENCY, NOISE_ADAPTIVE, LEVEL_UNKNOWN, NOISE_UNKNOWN, EAR_PAUSE_ONE_OUT, LID_UNKNOWN, MAX_ERROR_CHARS }"
+  source + "; return { parseStatus, podFrom, defaultPod, noiseModeVerb, earDetectionVerb, earDetectionName, levelFraction, levelText, podMeta, elideError, availableModes, NOISE_OFF, NOISE_ANC, NOISE_TRANSPARENCY, NOISE_ADAPTIVE, LEVEL_UNKNOWN, NOISE_UNKNOWN, EAR_PAUSE_ONE_OUT, EAR_PAUSE_BOTH_OUT, EAR_DISABLED, LID_UNKNOWN, MAX_ERROR_CHARS }"
 )()
 
 let failures = 0
@@ -68,6 +68,12 @@ check("noise verb for an unknown mode is empty", Model.noiseModeVerb(Model.NOISE
 check("noise verb past the end is empty", Model.noiseModeVerb(4), "")
 check("ear verb for never pause", Model.earDetectionVerb(2), "ear:off")
 check("ear verb past the end is empty", Model.earDetectionVerb(3), "")
+
+// Ear detection labels, which are the only thing a headset changes about this row.
+check("earbuds name the pods", Model.earDetectionName(Model.EAR_PAUSE_ONE_OUT, false), "Pause when one is out")
+check("a headset never mentions pods", Model.earDetectionName(Model.EAR_PAUSE_ONE_OUT, true), "Pause when either side is off")
+check("a headset reads both-out as taken off", Model.earDetectionName(Model.EAR_PAUSE_BOTH_OUT, true), "Pause when taken off")
+check("never pause reads the same either way", Model.earDetectionName(Model.EAR_DISABLED, true), "Never pause")
 
 // Meter and label edges.
 check("an unknown level draws an empty track", Model.levelFraction(Model.LEVEL_UNKNOWN), 0)


### PR DESCRIPTION
The Ear detection row reads "Pause when one is out" or "Pause when both are out". A Max is one thing you put on your head, so neither sentence describes something you can do to it. The daemon rules are right, the words are wrong, so this changes only the words, and only when `is_headset` is set.

- one-out now reads "Pause when either side is off"
- both-out now reads "Pause when taken off"
- "Never pause" is the same either way

![The omapods panel with an AirPods Max connected](https://raw.githubusercontent.com/TerrifiedBug/omarchy-pods/385d2c6080e4b0028891f0e3ad64f013418c0b46/airpods-max-panel.png)

Earbuds read exactly as they did. The daemon still receives `ear:one`, `ear:both` and `ear:off`, the three-state cycle is untouched, and the row keeps its slot in `cursorRows` and its `e` shortcut, so keyboard navigation does not change.

Checks: `deno run --allow-read tests/model.test.js` passes, including four new cases covering both label sets. The screenshot is this branch running after `omarchy-restart-shell` with a Max connected and the behaviour set to both-out.

One thing I left alone. On a Max the two ear detection channels probably track the same on-head sensor, which would make one-out and both-out the same setting, and the panel would then show two names for one behaviour. I have not measured those bytes, so I kept both reachable instead of collapsing the cycle on a guess.
